### PR TITLE
Remove dummy data we pass into functions & unit tests

### DIFF
--- a/src/functions/sendCandidateResults/application/service/__tests__/send-email.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/__tests__/send-email.spec.ts
@@ -1,0 +1,57 @@
+import { sendEmail } from '../send-email';
+import { mockEmail1, completedCatBTest } from '../../../framework/__mocks__/test-data.mock';
+import { EmailPersonalisation } from '../../../domain/personalisation.model';
+import { INotifyClient } from '../../../domain/notify-client.interface';
+import { NotifyClientStubSuccess } from '../../stub/notify-client-stub-success';
+import { NotifyClientStubFailure400 } from '../../stub/notify-client-stub-failure-400';
+import { NotifyClientStubFailure500 } from '../../stub/notify-client-stub-failure-500';
+import { DocumentsServiceError } from '../../../domain/errors/documents-service-error';
+
+const personlisation : EmailPersonalisation = {
+  'first name': 'Fred',
+  'ref number': '12345',
+  'test date': '10/10/10',
+  'test time': '10:00',
+  'cat dead': 'it is?',
+};
+
+describe('sendEmail' , () => {
+
+  it('should successfully send an email', (async() => {
+    const notifyClient: INotifyClient = new NotifyClientStubSuccess();
+
+    const result =
+        await sendEmail(mockEmail1,  'temp-id', personlisation,  'app-ref',  'reply-id', notifyClient);
+
+    expect(result).toBe(undefined);
+
+  }));
+
+  it('should return a error with a negative retry flag for a 400 error', (async() => {
+    const notifyClient: INotifyClient = new NotifyClientStubFailure400();
+
+    try {
+      await sendEmail(mockEmail1,  'temp-id', personlisation,  'app-ref',  'reply-id', notifyClient);
+    } catch (err) {
+
+      const documentsServiceError: DocumentsServiceError = err as DocumentsServiceError;
+      expect(documentsServiceError.statusCode).toBe(400);
+      expect(documentsServiceError.message).toBe('Can\'t send to this recipient using a team-only API key');
+      expect(documentsServiceError.shouldRetry).toBe(false);
+    }
+  }));
+
+  it('should return a error with a positive retry flag for a 500 error', (async() => {
+    const notifyClient: INotifyClient = new NotifyClientStubFailure500();
+
+    try {
+      await sendEmail(mockEmail1,  'temp-id', personlisation,  'app-ref',  'reply-id', notifyClient);
+    } catch (err) {
+
+      const documentsServiceError: DocumentsServiceError = err as DocumentsServiceError;
+      expect(documentsServiceError.statusCode).toBe(500);
+      expect(documentsServiceError.message).toBe('Internal server error');
+      expect(documentsServiceError.shouldRetry).toBe(true);
+    }
+  }));
+});

--- a/src/functions/sendCandidateResults/application/service/__tests__/send-letter.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/__tests__/send-letter.spec.ts
@@ -1,13 +1,15 @@
-import { sendEmail } from '../send-email';
-import { mockEmail1 } from '../../../framework/__mocks__/test-data.mock';
-import { EmailPersonalisation } from '../../../domain/personalisation.model';
+import { sendLetter } from '../send-letter';
+import { LetterPersonalisation } from '../../../domain/personalisation.model';
 import { INotifyClient } from '../../../domain/notify-client.interface';
 import { NotifyClientStubSuccess } from '../../stub/notify-client-stub-success';
 import { NotifyClientStubFailure400 } from '../../stub/notify-client-stub-failure-400';
 import { NotifyClientStubFailure500 } from '../../stub/notify-client-stub-failure-500';
 import { DocumentsServiceError } from '../../../domain/errors/documents-service-error';
 
-const personlisation : EmailPersonalisation = {
+const personlisation : LetterPersonalisation = {
+  address_line_1: 'address line 1',
+  address_line_2: 'address line 2',
+  postcode: 'postcode',
   'first name': 'Fred',
   'ref number': '12345',
   'test date': '10/10/10',
@@ -15,13 +17,12 @@ const personlisation : EmailPersonalisation = {
   'cat dead': 'it is?',
 };
 
-describe('sendEmail' , () => {
+describe('sendLetter' , () => {
 
-  it('should successfully send an email', (async() => {
+  it('should successfully send a letter', (async() => {
     const notifyClient: INotifyClient = new NotifyClientStubSuccess();
 
-    const result =
-        await sendEmail(mockEmail1,  'temp-id', personlisation,  'app-ref',  'reply-id', notifyClient);
+    const result = await sendLetter('template-id', personlisation, 'ref', notifyClient);
 
     expect(result).toBe(undefined);
 
@@ -31,7 +32,7 @@ describe('sendEmail' , () => {
     const notifyClient: INotifyClient = new NotifyClientStubFailure400();
 
     try {
-      await sendEmail(mockEmail1,  'temp-id', personlisation,  'app-ref',  'reply-id', notifyClient);
+      await sendLetter('template-id', personlisation, 'ref', notifyClient);
     } catch (err) {
 
       const documentsServiceError: DocumentsServiceError = err as DocumentsServiceError;
@@ -45,7 +46,7 @@ describe('sendEmail' , () => {
     const notifyClient: INotifyClient = new NotifyClientStubFailure500();
 
     try {
-      await sendEmail(mockEmail1,  'temp-id', personlisation,  'app-ref',  'reply-id', notifyClient);
+      await sendLetter('template-id', personlisation, 'ref', notifyClient);
     } catch (err) {
 
       const documentsServiceError: DocumentsServiceError = err as DocumentsServiceError;

--- a/src/functions/sendCandidateResults/application/stub/notify-client-stub-failure-400.ts
+++ b/src/functions/sendCandidateResults/application/stub/notify-client-stub-failure-400.ts
@@ -15,11 +15,13 @@ export class NotifyClientStubFailure400 implements INotifyClient {
     return Promise.reject({
       error: {
         status_code: 400,
-        errors: {
-          error: 'BadRequestError',
-          // tslint:disable-next-line
-          message: 'Can not send to this recipient when service is in trial mode - see www.notifications.service.gov.uk/trial-mode',
-        },
+        errors: [
+          {
+            error: 'BadRequestError',
+            // tslint:disable-next-line
+            message: 'Can not send to this recipient when service is in trial mode - see www.notifications.service.gov.uk/trial-mode',
+          },
+        ],
       },
     });
   }
@@ -33,11 +35,13 @@ export class NotifyClientStubFailure400 implements INotifyClient {
     return Promise.reject({
       error: {
         status_code: 400,
-        errors: {
-          error: 'BadRequestError',
-          // tslint:disable-next-line
-          message: 'Cannot send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode',
-        },
+        errors: [
+          {
+            error: 'BadRequestError',
+            // tslint:disable-next-line
+            message: 'Cannot send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode',
+          },
+        ],
       },
     });
   }

--- a/src/functions/sendCandidateResults/application/stub/notify-client-stub-failure-400.ts
+++ b/src/functions/sendCandidateResults/application/stub/notify-client-stub-failure-400.ts
@@ -18,8 +18,7 @@ export class NotifyClientStubFailure400 implements INotifyClient {
         errors: [
           {
             error: 'BadRequestError',
-            // tslint:disable-next-line
-            message: 'Can not send to this recipient when service is in trial mode - see www.notifications.service.gov.uk/trial-mode',
+            message: 'Can\'t send to this recipient using a team-only API key',
           },
         ],
       },
@@ -38,8 +37,7 @@ export class NotifyClientStubFailure400 implements INotifyClient {
         errors: [
           {
             error: 'BadRequestError',
-            // tslint:disable-next-line
-            message: 'Cannot send letters when service is in trial mode - see https://www.notifications.service.gov.uk/trial-mode',
+            message: 'Can\'t send to this recipient using a team-only API key',
           },
         ],
       },

--- a/src/functions/sendCandidateResults/application/stub/notify-client-stub-failure-500.ts
+++ b/src/functions/sendCandidateResults/application/stub/notify-client-stub-failure-500.ts
@@ -15,10 +15,12 @@ export class NotifyClientStubFailure500 implements INotifyClient {
     return Promise.reject({
       error: {
         status_code: 500,
-        errors: {
-          error: 'Exception',
-          message: 'Internal server error',
-        },
+        errors: [
+          {
+            error: 'Exception',
+            message: 'Internal server error',
+          },
+        ],
       },
     });
   }
@@ -32,10 +34,12 @@ export class NotifyClientStubFailure500 implements INotifyClient {
     return Promise.reject({
       error: {
         status_code: 500,
-        errors: {
-          error: 'Exception',
-          message: 'Internal server error',
-        },
+        errors: [
+          {
+            error: 'Exception',
+            message: 'Internal server error',
+          },
+        ],
       },
     });
   }

--- a/src/functions/sendCandidateResults/framework/request-scheduler.ts
+++ b/src/functions/sendCandidateResults/framework/request-scheduler.ts
@@ -67,7 +67,14 @@ export class RequestScheduler implements IRequestScheduler {
         'first name': 'Joe',
         'cat dead' : 'was black and white',
       };
-      return sendEmail('example@example.com', templateId, data, 'fake-ref', '', this.notifyClient);
+      return sendEmail(
+        testResult.communicationPreferences.updatedEmail,
+        templateId,
+        data,
+        'fake-ref',
+        '',
+        this.notifyClient,
+      );
     }
 
     const templateId: string = this.templateIdProvider.getLetterTemplateId(

--- a/src/functions/sendCandidateResults/framework/request-scheduler.ts
+++ b/src/functions/sendCandidateResults/framework/request-scheduler.ts
@@ -71,7 +71,7 @@ export class RequestScheduler implements IRequestScheduler {
         testResult.communicationPreferences.updatedEmail,
         templateId,
         data,
-        'fake-ref',
+        testResult.journalData.applicationReference.applicationId.toString(),
         '',
         this.notifyClient,
       );
@@ -97,7 +97,11 @@ export class RequestScheduler implements IRequestScheduler {
       'cat dead' : 'was black and white',
     };
 
-    return sendLetter(templateId, data, 'fake-ref', this.notifyClient);
+    return sendLetter(
+      templateId,
+      data,
+      testResult.journalData.applicationReference.applicationId.toString(),
+      this.notifyClient);
   }
 
   private onLimiterFailed(


### PR DESCRIPTION
- Now send email to actual email address
- Now use the application id as the notify  email reference 
- Update issues with the notify error mocks
- Unit tests for send-email.ts
- Unit tests for send-letter.ts