### PR TITLE
MES-3125-cherry-pick: Return empty string for template ID when the test outcome is terminated

### DIFF
--- a/src/functions/sendCandidateResults/application/service/__tests__/send-email.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/__tests__/send-email.spec.ts
@@ -30,7 +30,6 @@ describe('sendEmail', () => {
       await sendEmail(mockEmail1, 'temp-id', personlisation, '12345678', 'reply-id', notifyClient);
 
     expect(result).toBe(undefined);
-
   }));
 
   it('should return a error with a negative retry flag for a 400 error', (async () => {

--- a/src/functions/sendCandidateResults/application/service/__tests__/send-letter.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/__tests__/send-letter.spec.ts
@@ -6,7 +6,7 @@ import { NotifyClientStubFailure400 } from '../../stub/notify-client-stub-failur
 import { NotifyClientStubFailure500 } from '../../stub/notify-client-stub-failure-500';
 import { DocumentsServiceError } from '../../../domain/errors/documents-service-error';
 
-const personlisation : LetterPersonalisation = {
+const personlisation: LetterPersonalisation = {
   address_line_1: 'address line 1',
   address_line_2: 'address line 2',
   postcode: 'postcode',
@@ -23,18 +23,17 @@ const personlisation : LetterPersonalisation = {
   showSeriousFaults: BooleanText.YES,
 };
 
-describe('sendLetter' , () => {
+describe('sendLetter', () => {
 
-  it('should successfully send a letter', (async() => {
+  it('should successfully send a letter', (async () => {
     const notifyClient: INotifyClient = new NotifyClientStubSuccess();
 
     const result = await sendLetter('template-id', personlisation, 'ref', notifyClient);
 
     expect(result).toBe(undefined);
-
   }));
 
-  it('should return a error with a negative retry flag for a 400 error', (async() => {
+  it('should return a error with a negative retry flag for a 400 error', (async () => {
     const notifyClient: INotifyClient = new NotifyClientStubFailure400();
 
     try {
@@ -48,7 +47,7 @@ describe('sendLetter' , () => {
     }
   }));
 
-  it('should return a error with a positive retry flag for a 500 error', (async() => {
+  it('should return a error with a positive retry flag for a 500 error', (async () => {
     const notifyClient: INotifyClient = new NotifyClientStubFailure500();
 
     try {

--- a/src/functions/sendCandidateResults/application/service/__tests__/template-id-provider.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/__tests__/template-id-provider.spec.ts
@@ -23,6 +23,9 @@ describe('get-template-id-provider', () => {
       it('should return the welsh email fail template', () => {
         expect(templateIdProvider.getEmailTemplateId('Cymraeg', '2')).toBe('email-welsh-fail-template-id');
       });
+      it('should return empty string for terminated tests', () => {
+        expect(templateIdProvider.getEmailTemplateId('English', '51')).toBe(TemplateIdProvider.TEMPLATE_ID_NOT_SET);
+      });
     });
 
     describe('getLetterTemplateId', () => {
@@ -37,6 +40,9 @@ describe('get-template-id-provider', () => {
       });
       it('should return the welsh post fail template', () => {
         expect(templateIdProvider.getLetterTemplateId('Cymraeg', '2')).toBe('post-welsh-fail-template-id');
+      });
+      it('should return empty string for terminated tests', () => {
+        expect(templateIdProvider.getLetterTemplateId('English', '51')).toBe(TemplateIdProvider.TEMPLATE_ID_NOT_SET);
       });
     });
   });

--- a/src/functions/sendCandidateResults/application/service/__tests__/terminated-test.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/__tests__/terminated-test.spec.ts
@@ -1,0 +1,205 @@
+import { NotifyClientStubSuccess } from '../../stub/notify-client-stub-success';
+import { INotifyClient } from '../../../domain/notify-client.interface';
+import { RequestScheduler } from '../../../framework/request-scheduler';
+import { IConfigAdapter } from '../../../framework/adapter/config/config-adapter.interface';
+import { ITemplateIdProvider, TemplateIdProvider } from '../template-id-provider';
+import { IStatusUpdater } from '../../../framework/status-updater';
+import { IFaultProvider, FaultProvider } from '../fault-provider';
+import { IPersonalisationProvider, PersonalisationProvider } from '../personalisation-provider';
+import { StandardCarTestCATBSchema } from '@dvsa/mes-test-schema/categories/B';
+import { ConfigAdapterMock } from '../../../framework/adapter/config/__mocks__/config-adapter.mock';
+import { StatusUpdaterMock } from '../../../framework/__mocks__/status-updater.mock';
+import { NextUploadBatchMock } from '../../../framework/__mocks__/next-upload-batch.mock';
+import { NOTIFY_INTERFACE } from '../../../domain/interface.constants';
+import { ProcessingStatus } from '../../../domain/submission-outcome.model';
+
+describe('Test termination confirmation', () => {
+  let configAdapter: IConfigAdapter;
+  let templateIdProvider: ITemplateIdProvider;
+  let statusUpdater: IStatusUpdater;
+  let faultProvider: IFaultProvider;
+  let personalisationProvider: IPersonalisationProvider;
+
+  const totalNumberOfTests: number = 1;
+
+  let testResults: StandardCarTestCATBSchema[];
+  beforeEach(async () => {
+    configAdapter = new ConfigAdapterMock();
+    templateIdProvider = new TemplateIdProvider(configAdapter);
+    statusUpdater = new StatusUpdaterMock();
+    faultProvider = new FaultProvider();
+    personalisationProvider = new PersonalisationProvider(faultProvider);
+
+    spyOn(statusUpdater, 'updateStatus');
+
+    testResults = await new NextUploadBatchMock().get(totalNumberOfTests);
+  });
+
+  describe('Terminated test sendEmail handling', () => {
+    it('should not send an email when templateId is empty', async (done) => {
+      const notifyClient: INotifyClient = new NotifyClientStubSuccess();
+      testResults.forEach(result => result.activityCode = '11');
+      const requestScheduler =
+        new RequestScheduler(configAdapter, notifyClient, templateIdProvider, personalisationProvider, statusUpdater);
+
+      spyOn(notifyClient, 'sendEmail');
+      await requestScheduler.scheduleRequests(testResults);
+
+      setTimeout(() => {
+        expect(notifyClient.sendEmail).not.toHaveBeenCalled();
+        expect(statusUpdater.updateStatus).toHaveBeenCalledWith({
+          applicationReference: 12345672011,
+          outcomePayload: {
+            interface: NOTIFY_INTERFACE,
+            state: ProcessingStatus.ACCEPTED,
+            staff_number: '123456',
+            retry_count: 0,
+            error_message: null,
+          },
+        });
+        done();
+      },         1000);
+    });
+
+    it('should send an email for terminated activity code 4', async (done) => {
+      const notifyClient: INotifyClient = new NotifyClientStubSuccess();
+      testResults.forEach(result => result.activityCode = '4');
+      const requestScheduler =
+        new RequestScheduler(configAdapter, notifyClient, templateIdProvider, personalisationProvider, statusUpdater);
+
+      spyOn(notifyClient, 'sendEmail');
+      await requestScheduler.scheduleRequests(testResults);
+
+      setTimeout(() => {
+        expect(notifyClient.sendEmail).toHaveBeenCalled();
+        expect(statusUpdater.updateStatus).toHaveBeenCalledWith({
+          applicationReference: 12345672011,
+          outcomePayload: {
+            interface: NOTIFY_INTERFACE,
+            state: ProcessingStatus.ACCEPTED,
+            staff_number: '123456',
+            retry_count: 0,
+            error_message: null,
+          },
+        });
+        done();
+      },         1000);
+    });
+
+    it('should send an email for terminated activity code 5', async (done) => {
+      const notifyClient: INotifyClient = new NotifyClientStubSuccess();
+      testResults.forEach(result => result.activityCode = '5');
+      const requestScheduler =
+        new RequestScheduler(configAdapter, notifyClient, templateIdProvider, personalisationProvider, statusUpdater);
+
+      spyOn(notifyClient, 'sendEmail');
+      await requestScheduler.scheduleRequests(testResults);
+
+      setTimeout(() => {
+        expect(notifyClient.sendEmail).toHaveBeenCalled();
+        expect(statusUpdater.updateStatus).toHaveBeenCalledWith({
+          applicationReference: 12345672011,
+          outcomePayload: {
+            interface: NOTIFY_INTERFACE,
+            state: ProcessingStatus.ACCEPTED,
+            staff_number: '123456',
+            retry_count: 0,
+            error_message: null,
+          },
+        });
+        done();
+      },         1000);
+    });
+  });
+
+  describe('Terminated test sendLetter handling', () => {
+    it('should not send an email when templateId is empty', async (done) => {
+      const notifyClient: INotifyClient = new NotifyClientStubSuccess();
+      testResults.forEach(result => result.activityCode = '11');
+      const requestScheduler =
+        new RequestScheduler(configAdapter, notifyClient, templateIdProvider, personalisationProvider, statusUpdater);
+
+      spyOn(notifyClient, 'sendLetter');
+      await requestScheduler.scheduleRequests(testResults);
+
+      setTimeout(() => {
+        expect(notifyClient.sendLetter).not.toHaveBeenCalled();
+        expect(statusUpdater.updateStatus).toHaveBeenCalledWith({
+          applicationReference: 12345672011,
+          outcomePayload: {
+            interface: NOTIFY_INTERFACE,
+            state: ProcessingStatus.ACCEPTED,
+            staff_number: '123456',
+            retry_count: 0,
+            error_message: null,
+          },
+        });
+        done();
+      },         1000);
+    });
+
+    it('should send a letter for terminated activity code 4', async (done) => {
+      const notifyClient: INotifyClient = new NotifyClientStubSuccess();
+      testResults.forEach((result) => {
+        result.activityCode = '4';
+        result.communicationPreferences = {
+          updatedEmail: '',
+          communicationMethod: 'Post',
+          conductedLanguage: 'English',
+        };
+      });
+      const requestScheduler =
+        new RequestScheduler(configAdapter, notifyClient, templateIdProvider, personalisationProvider, statusUpdater);
+
+      spyOn(notifyClient, 'sendLetter');
+      await requestScheduler.scheduleRequests(testResults);
+
+      setTimeout(() => {
+        expect(notifyClient.sendLetter).toHaveBeenCalled();
+        expect(statusUpdater.updateStatus).toHaveBeenCalledWith({
+          applicationReference: 12345672011,
+          outcomePayload: {
+            interface: NOTIFY_INTERFACE,
+            state: ProcessingStatus.ACCEPTED,
+            staff_number: '123456',
+            retry_count: 0,
+            error_message: null,
+          },
+        });
+        done();
+      },         1000);
+    });
+
+    it('should send a letter for terminated activity code 5', async (done) => {
+      const notifyClient: INotifyClient = new NotifyClientStubSuccess();
+      testResults.forEach((result) => {
+        result.activityCode = '5';
+        result.communicationPreferences = {
+          updatedEmail: '',
+          communicationMethod: 'Post',
+          conductedLanguage: 'English',
+        };
+      });
+      const requestScheduler =
+        new RequestScheduler(configAdapter, notifyClient, templateIdProvider, personalisationProvider, statusUpdater);
+
+      spyOn(notifyClient, 'sendLetter');
+      await requestScheduler.scheduleRequests(testResults);
+
+      setTimeout(() => {
+        expect(notifyClient.sendLetter).toHaveBeenCalled();
+        expect(statusUpdater.updateStatus).toHaveBeenCalledWith({
+          applicationReference: 12345672011,
+          outcomePayload: {
+            interface: NOTIFY_INTERFACE,
+            state: ProcessingStatus.ACCEPTED,
+            staff_number: '123456',
+            retry_count: 0,
+            error_message: null,
+          },
+        });
+        done();
+      },         1000);
+    });
+  });
+});

--- a/src/functions/sendCandidateResults/application/service/send-letter.ts
+++ b/src/functions/sendCandidateResults/application/service/send-letter.ts
@@ -3,10 +3,10 @@ import { LetterPersonalisation } from '../../domain/personalisation.model';
 import { INotifyClient } from '../../domain/notify-client.interface';
 
 export async function sendLetter(
-    templateId: string,
-    personalisation: LetterPersonalisation,
-    reference: string,
-    notifyClient: INotifyClient,
+  templateId: string,
+  personalisation: LetterPersonalisation,
+  reference: string,
+  notifyClient: INotifyClient,
 ) {
 
   try {

--- a/src/functions/sendCandidateResults/application/service/template-id-provider.ts
+++ b/src/functions/sendCandidateResults/application/service/template-id-provider.ts
@@ -12,7 +12,7 @@ export interface ITemplateIdProvider {
 
 @injectable()
 export class TemplateIdProvider implements ITemplateIdProvider {
-
+  static TEMPLATE_ID_NOT_SET = 'Template Id not set';
   constructor(@inject(TYPES.IConfigAdapter) private configAdapter: IConfigAdapter) {
   }
 
@@ -24,7 +24,7 @@ export class TemplateIdProvider implements ITemplateIdProvider {
       if (isFail(activityCode)) {
         return this.configAdapter.welshEmailFailTemplateId;
       }
-      isTerminated(activityCode);
+      return TemplateIdProvider.TEMPLATE_ID_NOT_SET;
     }
     if (isPass(activityCode)) {
       return this.configAdapter.englishEmailPassTemplateId;
@@ -32,8 +32,7 @@ export class TemplateIdProvider implements ITemplateIdProvider {
     if (isFail(activityCode)) {
       return this.configAdapter.englishEmailFailTemplateId;
     }
-    isTerminated(activityCode);
-    return '';
+    return TemplateIdProvider.TEMPLATE_ID_NOT_SET;
   }
 
   getLetterTemplateId(language: ConductedLanguage, activityCode: ActivityCode): string {
@@ -44,16 +43,16 @@ export class TemplateIdProvider implements ITemplateIdProvider {
       if (isFail(activityCode)) {
         return this.configAdapter.welshLetterFailTemplateId;
       }
-      isTerminated(activityCode);
+      return TemplateIdProvider.TEMPLATE_ID_NOT_SET;
     }
+
     if (isPass(activityCode)) {
       return this.configAdapter.englishLetterPassTemplateId;
     }
     if (isFail(activityCode)) {
       return this.configAdapter.englishLetterFailTemplateId;
     }
-    isTerminated(activityCode);
-    return '';
+    return TemplateIdProvider.TEMPLATE_ID_NOT_SET;
   }
 }
 
@@ -61,13 +60,6 @@ export function isPass(activityCode: ActivityCode): boolean {
   return activityCode === '1';
 }
 
-export function isFail(activityCode: ActivityCode) : boolean {
+export function isFail(activityCode: ActivityCode): boolean {
   return activityCode === '2' || activityCode === '3' || activityCode === '4' || activityCode === '5';
-}
-
-export function isTerminated(activityCode: ActivityCode) : void {
-  throw new DocumentsServiceError(
-     0 ,
-     `Failed to get template id for activity code ${ activityCode }`,
-     false);
 }

--- a/src/functions/sendCandidateResults/framework/request-scheduler.ts
+++ b/src/functions/sendCandidateResults/framework/request-scheduler.ts
@@ -5,7 +5,7 @@ import { inject, injectable } from 'inversify';
 import { TYPES } from './di/types';
 import { StandardCarTestCATBSchema, ApplicationReference } from '@dvsa/mes-test-schema/categories/B';
 import { INotifyClient } from '../domain/notify-client.interface';
-import { ITemplateIdProvider } from '../application/service/template-id-provider';
+import { ITemplateIdProvider, isFail, isPass } from '../application/service/template-id-provider';
 import { sendEmail } from '../application/service/send-email';
 import { sendLetter } from '../application/service/send-letter';
 import { IPersonalisationProvider } from '../application/service/personalisation-provider';
@@ -112,12 +112,17 @@ export class RequestScheduler implements IRequestScheduler {
       return Promise.reject();
     }
 
+    if (!isFail(testResult.activityCode) && !isPass(testResult.activityCode)) {
+      return Promise.resolve();
+    }
+
     if (testResult.communicationPreferences.communicationMethod === 'Email') {
       const templateId: string =
         this.templateIdProvider.getEmailTemplateId(
           testResult.communicationPreferences.conductedLanguage,
           testResult.activityCode,
         );
+
       return sendEmail(
         testResult.communicationPreferences.updatedEmail,
         templateId,


### PR DESCRIPTION
Original PR for develop: https://github.com/dvsa/mes-documents-service/pull/44