### PR TITLE
mes-3185 - pass certificate number bump version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -128,9 +128,9 @@
       }
     },
     "@dvsa/mes-test-schema": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-2.0.2.tgz",
-      "integrity": "sha512-XTxqs8gEbvTJhrtl6Sg0vovmeOQJBWLWNpCcmi2f/ZLO8/4vsRh89RHs3T9FQ39+nZ8WFOnnVsANKKLe/9C7mw==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-2.0.3.tgz",
+      "integrity": "sha512-FPwvOkSGsjmyBSIVeJ1GbrKPmJFJ1i4Yea7flcFqK6JtjxttD49/DkdPQV7k3fcSBmLAoXMVUPIibxTuoAR0Mw==",
       "dev": true
     },
     "@fimbul/bifrost": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "notifications-node-client": "^4.6.0"
   },
   "devDependencies": {
-    "@dvsa/mes-test-schema": "2.0.2",
+    "@dvsa/mes-test-schema": "2.0.3",
     "@types/aws-lambda": "^8.10.18",
     "@types/aws-sdk": "^2.7.0",
     "@types/axios": "^0.14.0",


### PR DESCRIPTION
Bump `mes-test-schema` version from `2.0.2` to `2.0.3`