### PR TITLE
mes-3185 - bump test schema version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -121,9 +121,9 @@
       }
     },
     "@dvsa/mes-test-schema": {
-      "version": "1.0.34",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-1.0.34.tgz",
-      "integrity": "sha512-PJ8h4MzRktUbnk8jO8KZ6RRvWpPKuoMtE1tHCE5toClmPHeOIv4aZIKQUx6GYAodAQuOJlsxLgSf/oCRD+aLHA=="
+      "version": "1.0.35",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-1.0.35.tgz",
+      "integrity": "sha512-lETOiiNnY/ajOo75NBU0gP41+mVMLMskxcJTen4R0NvqsAqmOI0Bf9KLKvJUcF7ndEpe+ohGaiALEogjnRUnxg=="
     },
     "@fimbul/bifrost": {
       "version": "0.17.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "notifications-node-client": "^4.6.0"
   },
   "devDependencies": {
-    "@dvsa/mes-test-schema": "1.0.34",
+    "@dvsa/mes-test-schema": "1.0.35",
     "@types/aws-lambda": "^8.10.18",
     "@types/aws-sdk": "^2.7.0",
     "@types/axios": "^0.14.0",


### PR DESCRIPTION
Bump mes-test-schema from 1.0.34 to 1.0.35 and updated package lock