### PR TITLE
update schema and fix unit tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -128,9 +128,9 @@
       }
     },
     "@dvsa/mes-test-schema": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.0.0.tgz",
-      "integrity": "sha512-MR4VJR7gsBB5f7rW8d99XAyT8+tlcVJSNDsPjJoeX61WFS1mWN40xyLSO+O8FrpJyXhRSlv+UGDQFjcH4a0T3w==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.2.3.tgz",
+      "integrity": "sha512-DQnQKKOZTo9swch9zvN0DQkOJlluMgjRXFLuRF6qJitl6ArUVlOIERQxrzY4s56mDUkXFAocovnO/HCwHw+lMA==",
       "dev": true
     },
     "@fimbul/bifrost": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "notifications-node-client": "^4.6.0"
   },
   "devDependencies": {
-    "@dvsa/mes-test-schema": "3.0.0",
+    "@dvsa/mes-test-schema": "3.2.3",
     "@types/aws-lambda": "^8.10.18",
     "@types/aws-sdk": "^2.7.0",
     "@types/axios": "^0.14.0",

--- a/src/functions/sendCandidateResults/application/service/__tests__/fault-provider.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/__tests__/fault-provider.spec.ts
@@ -1,10 +1,9 @@
 import {
     DrivingFaults,
     SeriousFaults,
-    Manoeuvres,
-    VehicleChecks,
     TestData,
-} from '@dvsa/mes-test-schema/categories/B';
+} from '@dvsa/mes-test-schema/categories/common';
+import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import {
     convertNumericFaultObjectToArray,
     convertBooleanFaultObjectToArray,
@@ -27,7 +26,7 @@ describe('fault-provider', () => {
 
     describe('getDrivingFaults', () => {
       it('should give us a list of faults from different sections of the test data', () => {
-        const data: TestData = {
+        const data: CatBUniqueTypes.TestData = {
           drivingFaults: {
             ancillaryControls: 1,
             awarenessPlanning: 0,
@@ -56,7 +55,7 @@ describe('fault-provider', () => {
 
     describe('getSeriousFaults', () => {
       it('should give us a list of faults from different sections of the test data', () => {
-        const data: TestData = {
+        const data: CatBUniqueTypes.TestData = {
           seriousFaults: {
             ancillaryControls: true,
             awarenessPlanning: false,
@@ -98,7 +97,7 @@ describe('fault-provider', () => {
 
     describe('getDangerousFaults', () => {
       it('should give us a list of faults from different sections of the test data', () => {
-        const data: TestData = {
+        const data: CatBUniqueTypes.TestData = {
           dangerousFaults: {
             ancillaryControls: true,
             awarenessPlanning: false,
@@ -209,7 +208,7 @@ describe('fault-provider', () => {
 
   describe('getCompletedManoeuvres', () => {
     it('should return 2 driving faults if there are control and observation driving faults', () => {
-      const data: Manoeuvres = {
+      const data: CatBUniqueTypes.Manoeuvres = {
         forwardPark: {
           selected: true,
           controlFault: CompetencyOutcome.DF,
@@ -225,7 +224,7 @@ describe('fault-provider', () => {
 
     });
     it('should not return any driving faults for a manoeuvre if selected is not true', () => {
-      const data: Manoeuvres = {
+      const data: CatBUniqueTypes.Manoeuvres = {
         forwardPark: {
           controlFault: CompetencyOutcome.DF,
           observationFault: CompetencyOutcome.DF,
@@ -238,7 +237,7 @@ describe('fault-provider', () => {
 
     });
     it('should only return driving faults for the type of fault we have requested', () => {
-      const data: Manoeuvres = {
+      const data: CatBUniqueTypes.Manoeuvres = {
         forwardPark: {
           selected: true,
           controlFault: CompetencyOutcome.S,
@@ -253,7 +252,7 @@ describe('fault-provider', () => {
 
     });
     it('should return faults for multiple manoeuvres if more then 1 exist', () => {
-      const data: Manoeuvres = {
+      const data: CatBUniqueTypes.Manoeuvres = {
         forwardPark: {
           selected: true,
           controlFault: CompetencyOutcome.DF,
@@ -272,7 +271,7 @@ describe('fault-provider', () => {
 
     });
     it('should return any empty array if no data is avalible', () => {
-      const data: Manoeuvres = {};
+      const data: CatBUniqueTypes.Manoeuvres = {};
 
       const result: Fault[] = getCompletedManoeuvres(data, CompetencyOutcome.DF);
 
@@ -283,7 +282,7 @@ describe('fault-provider', () => {
 
   describe('getVehicleChecksFault', () => {
     it('should find a dangerous fault if one exists', () => {
-      const data: VehicleChecks = {
+      const data: CatBUniqueTypes.VehicleChecks = {
         showMeQuestion: {
           outcome: CompetencyOutcome.D,
         },
@@ -296,7 +295,7 @@ describe('fault-provider', () => {
 
     });
     it('should not find a dangerous fault if one exists', () => {
-      const data: VehicleChecks = {
+      const data: CatBUniqueTypes.VehicleChecks = {
         showMeQuestion: {
           outcome: CompetencyOutcome.DF,
         },
@@ -308,7 +307,7 @@ describe('fault-provider', () => {
 
     });
     it('should find a serious fault if one exists', () => {
-      const data: VehicleChecks = {
+      const data: CatBUniqueTypes.VehicleChecks = {
         showMeQuestion: {
           outcome: CompetencyOutcome.S,
         },
@@ -321,7 +320,7 @@ describe('fault-provider', () => {
 
     });
     it('should not find a serious fault if one exists', () => {
-      const data: VehicleChecks = {
+      const data: CatBUniqueTypes.VehicleChecks = {
         showMeQuestion: {
           outcome: CompetencyOutcome.DF,
         },
@@ -333,7 +332,7 @@ describe('fault-provider', () => {
 
     });
     it('should find a driving fault if one exists', () => {
-      const data: VehicleChecks = {
+      const data: CatBUniqueTypes.VehicleChecks = {
         showMeQuestion: {
           outcome: CompetencyOutcome.DF,
         },
@@ -346,7 +345,7 @@ describe('fault-provider', () => {
 
     });
     it('should not find a serious fault if one exists', () => {
-      const data: VehicleChecks = {
+      const data: CatBUniqueTypes.VehicleChecks = {
         showMeQuestion: {
           outcome: CompetencyOutcome.S,
         },
@@ -358,7 +357,7 @@ describe('fault-provider', () => {
 
     });
     it('should only return one a driving fault if two exist', () => {
-      const data: VehicleChecks = {
+      const data: CatBUniqueTypes.VehicleChecks = {
         showMeQuestion: {
           outcome: CompetencyOutcome.DF,
         },

--- a/src/functions/sendCandidateResults/application/service/__tests__/terminated-test.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/__tests__/terminated-test.spec.ts
@@ -6,7 +6,7 @@ import { ITemplateIdProvider, TemplateIdProvider } from '../template-id-provider
 import { IStatusUpdater } from '../../../framework/status-updater';
 import { IFaultProvider, FaultProvider } from '../fault-provider';
 import { IPersonalisationProvider, PersonalisationProvider } from '../personalisation-provider';
-import { StandardCarTestCATBSchema } from '@dvsa/mes-test-schema/categories/B';
+import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import { ConfigAdapterMock } from '../../../framework/adapter/config/__mocks__/config-adapter.mock';
 import { StatusUpdaterMock } from '../../../framework/__mocks__/status-updater.mock';
 import { NextUploadBatchMock } from '../../../framework/__mocks__/next-upload-batch.mock';
@@ -22,7 +22,7 @@ describe('Test termination confirmation', () => {
 
   const totalNumberOfTests: number = 1;
 
-  let testResults: StandardCarTestCATBSchema[];
+  let testResults: CatBUniqueTypes.TestResult[];
   beforeEach(async () => {
     configAdapter = new ConfigAdapterMock();
     templateIdProvider = new TemplateIdProvider(configAdapter);

--- a/src/functions/sendCandidateResults/application/service/fault-provider.ts
+++ b/src/functions/sendCandidateResults/application/service/fault-provider.ts
@@ -1,10 +1,9 @@
 import {
   TestData,
   ManoeuvreOutcome,
-  VehicleChecks,
   QuestionOutcome,
-  ActivityCode,
-} from '@dvsa/mes-test-schema/categories/B';
+} from '@dvsa/mes-test-schema/categories/common';
+import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import { injectable } from 'inversify';
 import 'reflect-metadata';
 
@@ -24,7 +23,7 @@ export interface IFaultProvider {
 @injectable()
 export class FaultProvider implements IFaultProvider {
 
-  public getDrivingFaults(testData: TestData | undefined): Fault [] {
+  public getDrivingFaults(testData: CatBUniqueTypes.TestData | undefined): Fault [] {
     const drivingFaults: Fault[] = [];
 
     if (!testData) {
@@ -42,7 +41,7 @@ export class FaultProvider implements IFaultProvider {
     return drivingFaults;
   }
 
-  public getSeriousFaults(testData: TestData | undefined): Fault [] {
+  public getSeriousFaults(testData: CatBUniqueTypes.TestData | undefined): Fault [] {
     const seriousFaults: Fault[] = [];
 
     if (!testData) {
@@ -64,7 +63,7 @@ export class FaultProvider implements IFaultProvider {
     return seriousFaults;
   }
 
-  public getDangerousFaults(testData: TestData | undefined): Fault [] {
+  public getDangerousFaults(testData: CatBUniqueTypes.TestData | undefined): Fault [] {
     const dangerousFaults: Fault[] = [];
 
     if (!testData) {
@@ -97,7 +96,7 @@ export function  convertBooleanFaultObjectToArray(faults: any): Fault[] {
   .map((key) => { return { name: key , count: 1 } as Fault; });
 }
 
-export function getNonStandardFaults(testData: TestData, faultType: CompetencyOutcome) : Fault[] {
+export function getNonStandardFaults(testData: CatBUniqueTypes.TestData, faultType: CompetencyOutcome) : Fault[] {
   const faults: Fault[] = [];
 
 // Controlled Stop
@@ -140,7 +139,8 @@ export function getCompletedManoeuvres(manoeuvres : any, faultType: ManoeuvreOut
   return result;
 }
 
-export function getVehicleChecksFault(vehicleChecks: VehicleChecks, faultType: QuestionOutcome) : Fault[] {
+export function getVehicleChecksFault(vehicleChecks: CatBUniqueTypes.VehicleChecks,
+                                      faultType: QuestionOutcome) : Fault[] {
   if (faultType === 'D') {
     if (vehicleChecks.showMeQuestion && vehicleChecks.showMeQuestion.outcome === 'D') {
       return [{ name: Competencies.vehicleChecks, count: 1 }];

--- a/src/functions/sendCandidateResults/application/service/personalisation-provider.ts
+++ b/src/functions/sendCandidateResults/application/service/personalisation-provider.ts
@@ -4,12 +4,12 @@ import {
   Personalisation,
   BooleanText,
 } from '../../domain/personalisation.model';
+import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import {
-  StandardCarTestCATBSchema,
   Name,
   ConductedLanguage,
   Eco,
-} from '@dvsa/mes-test-schema/categories/B';
+} from '@dvsa/mes-test-schema/categories/common';
 import { inject, injectable } from 'inversify';
 import { TYPES } from '../../framework/di/types';
 import { IFaultProvider } from './fault-provider';
@@ -22,9 +22,9 @@ import 'moment/locale/cy';
 
 export interface IPersonalisationProvider {
 
-  getEmailPersonalisation(testresult: StandardCarTestCATBSchema): EmailPersonalisation;
+  getEmailPersonalisation(testresult: CatBUniqueTypes.TestResult): EmailPersonalisation;
 
-  getLetterPersonalisation(testresult: StandardCarTestCATBSchema): LetterPersonalisation;
+  getLetterPersonalisation(testresult: CatBUniqueTypes.TestResult): LetterPersonalisation;
 }
 
 @injectable()
@@ -34,7 +34,7 @@ export class PersonalisationProvider implements IPersonalisationProvider {
     @inject(TYPES.IFaultProvider) private faultProvider: IFaultProvider,
   ) { }
 
-  public getEmailPersonalisation(testresult: StandardCarTestCATBSchema): EmailPersonalisation {
+  public getEmailPersonalisation(testresult: CatBUniqueTypes.TestResult): EmailPersonalisation {
     const sharedValues: Personalisation = this.getSharedPersonalisationValues(testresult);
 
     return {
@@ -42,7 +42,7 @@ export class PersonalisationProvider implements IPersonalisationProvider {
     };
   }
 
-  public getLetterPersonalisation(testresult: StandardCarTestCATBSchema): LetterPersonalisation {
+  public getLetterPersonalisation(testresult: CatBUniqueTypes.TestResult): LetterPersonalisation {
     const sharedValues: Personalisation = this.getSharedPersonalisationValues(testresult);
 
     return {
@@ -57,7 +57,7 @@ export class PersonalisationProvider implements IPersonalisationProvider {
     };
   }
 
-  private getSharedPersonalisationValues(testresult: StandardCarTestCATBSchema): Personalisation {
+  private getSharedPersonalisationValues(testresult: CatBUniqueTypes.TestResult): Personalisation {
 
     const drivingFaults = this.buildFaultStringWithCount(
       this.faultProvider.getDrivingFaults(testresult.testData).sort((a, b) => b.count - a.count),

--- a/src/functions/sendCandidateResults/application/service/template-id-provider.ts
+++ b/src/functions/sendCandidateResults/application/service/template-id-provider.ts
@@ -1,5 +1,4 @@
-import { ActivityCode, ConductedLanguage } from '@dvsa/mes-test-schema/categories/B';
-import { DocumentsServiceError } from '../../domain/errors/documents-service-error';
+import { ActivityCode, ConductedLanguage } from '@dvsa/mes-test-schema/categories/common';
 import { IConfigAdapter } from '../../framework/adapter/config/config-adapter.interface';
 import { TYPES } from '../../framework/di/types';
 import { inject, injectable } from 'inversify';

--- a/src/functions/sendCandidateResults/framework/__mocks__/next-upload-batch.mock.ts
+++ b/src/functions/sendCandidateResults/framework/__mocks__/next-upload-batch.mock.ts
@@ -1,4 +1,4 @@
-import { StandardCarTestCATBSchema } from '@dvsa/mes-test-schema/categories/B';
+import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import { completedCatBTest } from './test-data.mock';
 import { INextUploadBatch } from '../../domain/next-upload-batch.interface';
 import { injectable } from 'inversify';
@@ -8,10 +8,10 @@ import { cloneDeep } from 'lodash';
 export class NextUploadBatchMock implements INextUploadBatch {
 
   get(batchSize: number = 250) {
-    const data: StandardCarTestCATBSchema[] = [];
+    const data: CatBUniqueTypes.TestResult[] = [];
 
     for (let i = 0 ; i < batchSize; i = i + 1) {
-      const result: StandardCarTestCATBSchema = cloneDeep(completedCatBTest);
+      const result: CatBUniqueTypes.TestResult = cloneDeep(completedCatBTest);
       result.journalData.applicationReference.applicationId =
       result.journalData.applicationReference.applicationId + 1;
       data.push(result);

--- a/src/functions/sendCandidateResults/framework/__mocks__/test-data.mock.ts
+++ b/src/functions/sendCandidateResults/framework/__mocks__/test-data.mock.ts
@@ -1,4 +1,4 @@
-import { StandardCarTestCATBSchema } from '@dvsa/mes-test-schema/categories/B';
+import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 
 export const mockEmail1 = 'simulate-delivered@notifications.service.gov.uk';
 export const mockEmail2 = 'simulate-delivered-2@notifications.service.gov.uk';
@@ -14,7 +14,7 @@ export const mockPhoneNumber3 = '07700900222';
 export const temporaryFailurePhoneNumber = '07700900003';
 export const permanentFailurePhoneNumber = '07700900002';
 
-export const completedCatBTest: StandardCarTestCATBSchema = {
+export const completedCatBTest: CatBUniqueTypes.TestResult = {
   version: '0.1.1',
   category: 'B',
   activityCode: '1',

--- a/src/functions/sendCandidateResults/framework/__tests__/request-scheduler.spec.ts
+++ b/src/functions/sendCandidateResults/framework/__tests__/request-scheduler.spec.ts
@@ -4,7 +4,7 @@ import { ConfigAdapterMock } from '../adapter/config/__mocks__/config-adapter.mo
 import { INotifyClient } from '../../domain/notify-client.interface';
 import { NotifyClientStubSuccess } from '../../application/stub/notify-client-stub-success';
 import { ITemplateIdProvider, TemplateIdProvider } from '../../application/service/template-id-provider';
-import { StandardCarTestCATBSchema } from '@dvsa/mes-test-schema/categories/B';
+import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import { IStatusUpdater } from '../status-updater';
 import { NotifyClientStubFailure500 } from '../../application/stub/notify-client-stub-failure-500';
 import { NextUploadBatchMock } from '../__mocks__/next-upload-batch.mock';
@@ -26,7 +26,7 @@ describe('RequestScheduler', () => {
 
   const totalNumberOfTests: number = 1;
 
-  let testResults: StandardCarTestCATBSchema[];
+  let testResults: CatBUniqueTypes.TestResult[];
 
   beforeEach(async() => {
     configAdapter = new ConfigAdapterMock();

--- a/src/functions/sendCandidateResults/framework/handler.ts
+++ b/src/functions/sendCandidateResults/framework/handler.ts
@@ -1,12 +1,12 @@
 import { container } from './di/inversify.config';
 import { TYPES } from './di/types';
-import { StandardCarTestCATBSchema } from '@dvsa/mes-test-schema/categories/B';
+import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import { IRequestScheduler } from './request-scheduler';
 import { INextUploadBatch } from '../domain/next-upload-batch.interface';
 
 export async function handler() {
 
-  let testResults: StandardCarTestCATBSchema[];
+  let testResults: CatBUniqueTypes.TestResult[];
   const nextUploadBatch = container.get<INextUploadBatch>(TYPES.INextUploadBatch);
 
   try {

--- a/src/functions/sendCandidateResults/framework/next-upload-batch.ts
+++ b/src/functions/sendCandidateResults/framework/next-upload-batch.ts
@@ -1,6 +1,6 @@
 import { injectable, inject } from 'inversify';
 import axios, { AxiosResponse } from 'axios';
-import { StandardCarTestCATBSchema } from '@dvsa/mes-test-schema/categories/B';
+import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import * as zlib from 'zlib';
 
 import { INextUploadBatch } from '../domain/next-upload-batch.interface';
@@ -24,12 +24,12 @@ export class NextUploadBatch implements INextUploadBatch {
     const { resultsBaseApiUrl } = this.configAdapter;
     return axios.get(
       `${resultsBaseApiUrl}/test-results/upload?interface=${NOTIFY_INTERFACE}&batch_size=${this.batchSize}`,
-    ).then((response: AxiosResponse): StandardCarTestCATBSchema[] => {
+    ).then((response: AxiosResponse): CatBUniqueTypes.TestResult[] => {
       const parseResult = response.data;
-      const resultList: StandardCarTestCATBSchema[] = [];
+      const resultList: CatBUniqueTypes.TestResult[] = [];
       parseResult.forEach((element: string) => {
         let uncompressedResult: string = '';
-        let test: StandardCarTestCATBSchema;
+        let test: CatBUniqueTypes.TestResult;
 
         try {
           uncompressedResult = zlib.gunzipSync(new Buffer(element, 'base64')).toString();

--- a/src/functions/sendCandidateResults/framework/request-scheduler.ts
+++ b/src/functions/sendCandidateResults/framework/request-scheduler.ts
@@ -3,7 +3,7 @@ import { IConfigAdapter } from './adapter/config/config-adapter.interface';
 import { DocumentsServiceError } from '../domain/errors/documents-service-error';
 import { inject, injectable } from 'inversify';
 import { TYPES } from './di/types';
-import { StandardCarTestCATBSchema, ApplicationReference } from '@dvsa/mes-test-schema/categories/B';
+import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import { INotifyClient } from '../domain/notify-client.interface';
 import { ITemplateIdProvider, isFail, isPass } from '../application/service/template-id-provider';
 import { sendEmail } from '../application/service/send-email';
@@ -15,7 +15,7 @@ import { NOTIFY_INTERFACE } from '../domain/interface.constants';
 import { formatApplicationReference } from '@dvsa/mes-microservice-common/domain/tars';
 
 export interface IRequestScheduler {
-  scheduleRequests(testResults: StandardCarTestCATBSchema[]): Promise<void>[];
+  scheduleRequests(testResults: CatBUniqueTypes.TestResult[]): Promise<void>[];
 }
 
 @injectable()
@@ -69,8 +69,8 @@ export class RequestScheduler implements IRequestScheduler {
       });
   }
 
-  scheduleRequests(testResults: StandardCarTestCATBSchema[]): Promise<void>[] {
-    return testResults.map((testResult: StandardCarTestCATBSchema) => {
+  scheduleRequests(testResults: CatBUniqueTypes.TestResult[]): Promise<void>[] {
+    return testResults.map((testResult: CatBUniqueTypes.TestResult) => {
       const applicationReference = formatApplicationReference(
         testResult.journalData.applicationReference,
       );
@@ -114,7 +114,7 @@ export class RequestScheduler implements IRequestScheduler {
     });
   }
 
-  private sendNotifyRequest(testResult: StandardCarTestCATBSchema): Promise<any> {
+  private sendNotifyRequest(testResult: CatBUniqueTypes.TestResult): Promise<any> {
     if (!testResult.communicationPreferences) {
       return Promise.reject();
     }


### PR DESCRIPTION
Updating to use the latest test schema and fixing unit tests that were broken as a result.
making an entry in the tech debt section on confluence around refactoring the unit tests to be more schema aware ( or at least tests created for each category schema)