### PR TITLE
use latest test-schema npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -128,9 +128,9 @@
       }
     },
     "@dvsa/mes-test-schema": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.2.11.tgz",
-      "integrity": "sha512-eIA/pnmnStIzt6A/prgA0R7xD6S+EdGKsTAhT5K+RHu1Phlto2MdhCTlT9Nl7C/qopyNKWXDr03frVCXIah5bA==",
+      "version": "3.2.12",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.2.12.tgz",
+      "integrity": "sha512-3H7pvm5Ev8Vl2nb6RbwfIEVbiI7MDpCRtsl1FBGC5Y6ROv9tQGZ5BBC7qTQRuDuZmOsIIh5I63XLKKjhBYv8jQ==",
       "dev": true
     },
     "@fimbul/bifrost": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "notifications-node-client": "^4.6.0"
   },
   "devDependencies": {
-    "@dvsa/mes-test-schema": "3.2.11",
+    "@dvsa/mes-test-schema": "3.2.12",
     "@types/aws-lambda": "^8.10.18",
     "@types/aws-sdk": "^2.7.0",
     "@types/axios": "^0.14.0",


### PR DESCRIPTION
Updated to use the latest test-schema npm package to hopefully fix case sensitivity build issues.
