### PR TITLE
MES 4243 update cat BE reverse labels

### DIFF
--- a/src/functions/sendCandidateResults/domain/competencies.ts
+++ b/src/functions/sendCandidateResults/domain/competencies.ts
@@ -52,6 +52,7 @@ export enum Competencies {
     eyesightTest = 'eyesightTest',
     uncoupleRecouple = 'uncoupleRecouple',
     reverseLeftControl = 'reverseLeftControl',
+    reverseLeftObservation = 'reverseLeftObservation',
   }
 
 export enum englishCompetencyLabels {
@@ -106,6 +107,8 @@ export enum englishCompetencyLabels {
     controlledStop = 'Controlled Stop',
     vehicleChecks = 'Vehicle checks',
     eyesightTest = 'Eyesight test',
+    reverseLeftControl = 'Reverse - Control',
+    reverseLeftObservation = 'Reverse - Observation',
   }
 
 export enum welshCompetencyLabels {
@@ -160,4 +163,6 @@ export enum welshCompetencyLabels {
   controlledStop = 'Stopio dan Reolaeth',
   vehicleChecks = 'Gwirio’r cerbyd',
   eyesightTest = 'Prawf Golwg',
+  reverseLeftControl = 'Reverse - Control',
+  reverseLeftObservation = 'Reverse - Observation',
   }

--- a/src/functions/sendCandidateResults/domain/competencies.ts
+++ b/src/functions/sendCandidateResults/domain/competencies.ts
@@ -163,6 +163,6 @@ export enum welshCompetencyLabels {
   controlledStop = 'Stopio dan Reolaeth',
   vehicleChecks = 'Gwirio’r cerbyd',
   eyesightTest = 'Prawf Golwg',
-  reverseLeftControl = 'Reverse - Control',
-  reverseLeftObservation = 'Reverse - Observation',
+  reverseLeftControl = 'Bacio – dan reolaeth',
+  reverseLeftObservation = 'Bacio – gwyliadwriaeth',
   }


### PR DESCRIPTION
- Change displayed values on notify templates fro Cat B+E manouevres from 'Reverse Left' to 'Reverse'

![Screenshot 2019-12-11 at 15 24 15](https://user-images.githubusercontent.com/33055124/70634550-53e5e180-1c2a-11ea-94a5-5079d21753d7.png)

![Screenshot 2019-12-11 at 15 24 00](https://user-images.githubusercontent.com/33055124/70634554-55afa500-1c2a-11ea-8397-4aef185a4cba.png)
