### PR TITLE
MES 4223 Add ETA info to Notify templates

### DIFF
--- a/src/functions/sendCandidateResults/application/service/__tests__/personalisation-provider.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/__tests__/personalisation-provider.spec.ts
@@ -56,6 +56,9 @@ describe('personalisation-provider', () => {
       expect(result.showSeriousFaults).toEqual(BooleanText.YES);
       expect(result.showDangerousFaults).toEqual(BooleanText.YES);
       expect(result.showEcoText).toBe(BooleanText.NO);
+      expect(result.showEtaText).toEqual(BooleanText.YES);
+      expect(result.showEtaVerbal).toEqual(BooleanText.YES);
+      expect(result.showEtaPhysical).toEqual(BooleanText.NO);
     });
     it('should return welsh translations when required', () => {
       const personalisationProvider: IPersonalisationProvider = new PersonalisationProvider(faultProvider);
@@ -125,6 +128,9 @@ describe('personalisation-provider', () => {
       expect(result.showSeriousFaults).toEqual(BooleanText.YES);
       expect(result.showDangerousFaults).toEqual(BooleanText.YES);
       expect(result.showEcoText).toBe(BooleanText.NO);
+      expect(result.showEtaText).toEqual(BooleanText.YES);
+      expect(result.showEtaVerbal).toEqual(BooleanText.YES);
+      expect(result.showEtaPhysical).toEqual(BooleanText.NO);
     });
 
     it('should return welsh translations when required', () => {

--- a/src/functions/sendCandidateResults/application/service/__tests__/send-email.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/__tests__/send-email.spec.ts
@@ -19,6 +19,9 @@ const personlisation: EmailPersonalisation = {
   showDrivingFaults: BooleanText.YES,
   showEcoText: BooleanText.YES,
   showSeriousFaults: BooleanText.YES,
+  showEtaText: BooleanText.YES,
+  showEtaPhysical: BooleanText.YES,
+  showEtaVerbal: BooleanText.NO,
 };
 
 describe('sendEmail', () => {

--- a/src/functions/sendCandidateResults/application/service/__tests__/send-letter.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/__tests__/send-letter.spec.ts
@@ -21,6 +21,9 @@ const personlisation: LetterPersonalisation = {
   showDrivingFaults: BooleanText.YES,
   showEcoText: BooleanText.YES,
   showSeriousFaults: BooleanText.YES,
+  showEtaText: BooleanText.YES,
+  showEtaPhysical: BooleanText.YES,
+  showEtaVerbal: BooleanText.NO,
 };
 
 describe('sendLetter', () => {

--- a/src/functions/sendCandidateResults/application/service/personalisation-provider.ts
+++ b/src/functions/sendCandidateResults/application/service/personalisation-provider.ts
@@ -7,7 +7,7 @@ import {
 import {
   Name,
   ConductedLanguage,
-  Eco,
+  Eco, ETA,
 } from '@dvsa/mes-test-schema/categories/common';
 import { inject, injectable } from 'inversify';
 import { TYPES } from '../../framework/di/types';
@@ -71,6 +71,8 @@ export class PersonalisationProvider implements IPersonalisationProvider {
       this.faultProvider.getDangerousFaults(testresult.testData, testresult.category),
       get(testresult, 'communicationPreferences.conductedLanguage'));
 
+    const eta = get(testresult, 'testData.ETA', null);
+
     return {
       applicationReference: formatApplicationReference(get(testresult, 'journalData.applicationReference')),
       category: testresult.category,
@@ -90,6 +92,11 @@ export class PersonalisationProvider implements IPersonalisationProvider {
       showDangerousFaults: dangerousFaults.length > 0 ? BooleanText.YES : BooleanText.NO,
 
       showEcoText: this.shouldShowEco(get(testresult, 'testData.eco', null)),
+
+      showEtaText: this.shouldShowEta(eta),
+      showEtaVerbal: this.shouldShowEtaVerbal(eta),
+      showEtaPhysical: this.shouldShowEtaPhysical(eta),
+
     };
   }
 
@@ -134,6 +141,18 @@ export class PersonalisationProvider implements IPersonalisationProvider {
       return BooleanText.YES;
     }
     return BooleanText.NO;
+  }
+
+  private shouldShowEta(eta: ETA): BooleanText {
+    return eta && (eta.physical || eta.verbal) ? BooleanText.YES : BooleanText.NO;
+  }
+
+  private shouldShowEtaPhysical(eta: ETA): BooleanText {
+    return eta && eta.physical ? BooleanText.YES : BooleanText.NO;
+  }
+
+  private shouldShowEtaVerbal(eta: ETA): BooleanText {
+    return eta && eta.verbal ? BooleanText.YES : BooleanText.NO;
   }
 
   private formatDate(stringDate: Date, language: ConductedLanguage): string {

--- a/src/functions/sendCandidateResults/domain/personalisation.model.ts
+++ b/src/functions/sendCandidateResults/domain/personalisation.model.ts
@@ -19,6 +19,10 @@ export interface Personalisation {
   showDangerousFaults: BooleanText;
 
   showEcoText: BooleanText;
+
+  showEtaText: BooleanText;
+  showEtaVerbal: BooleanText;
+  showEtaPhysical: BooleanText;
 }
 
 export interface EmailPersonalisation extends Personalisation {

--- a/src/functions/sendCandidateResults/framework/__mocks__/test-data.mock.ts
+++ b/src/functions/sendCandidateResults/framework/__mocks__/test-data.mock.ts
@@ -140,5 +140,9 @@ export const completedCatBTest: CatBUniqueTypes.TestResult = {
         outcome: 'DF',
       },
     },
+    ETA: {
+      verbal: true,
+      physical: false,
+    },
   },
 };


### PR DESCRIPTION
Adds 3 ETA flags to notify data for display within failure templates

No ETAs Marked:
![Screenshot 2019-12-16 at 15 27 58](https://user-images.githubusercontent.com/33055124/70919619-15309c80-2019-11ea-8274-f9b30c8c0b43.png)

One ETA marked:
![Screenshot 2019-12-16 at 15 27 51](https://user-images.githubusercontent.com/33055124/70919648-224d8b80-2019-11ea-9191-a192dac49f00.png)

Both ETAs marked:
![Screenshot 2019-12-16 at 15 27 42](https://user-images.githubusercontent.com/33055124/70919715-3f825a00-2019-11ea-8d4b-d4275b1fd029.png)

