### PR TITLE
Mes 2703/notify cat c

### DIFF
--- a/src/functions/sendCandidateResults/application/service/__tests__/fault-provider.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/__tests__/fault-provider.spec.ts
@@ -1,8 +1,6 @@
-import {
-  DrivingFaults,
-  SeriousFaults,
-} from '@dvsa/mes-test-schema/categories/common';
+import { DrivingFaults, SeriousFaults } from '@dvsa/mes-test-schema/categories/common';
 import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 import {
   convertNumericFaultObjectToArray,
   convertBooleanFaultObjectToArray,
@@ -12,12 +10,11 @@ import {
 import { Fault } from '../../../domain/fault';
 import { CompetencyOutcome } from '../../../domain/competency-outcome';
 import { Competencies } from '../../../domain/competencies';
+
 import * as catBFaultProvider from '../categories/B/fault-provider-cat-b';
 import * as catBEFaultProvider from '../categories/BE/fault-provider-cat-be';
-import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+
 describe('fault-provider', () => {
-  const catB: string = TestCategory.B;
-  const catBE: string = TestCategory.BE;
 
   describe('FaultProvider', () => {
     let faultProvider: FaultProvider;
@@ -47,14 +44,14 @@ describe('fault-provider', () => {
           },
         };
 
-        faultProvider.getDrivingFaults(data, catB);
+        faultProvider.getDrivingFaults(data, TestCategory.B);
         expect(catBFaultProvider.getDrivingFaultsCatB).toHaveBeenCalledWith(data);
       });
 
       it('should call the cat be driving faults method when category is be', () => {
         spyOn(catBEFaultProvider, 'getDrivingFaultsCatBE');
         const data = {};
-        faultProvider.getDrivingFaults(data, catBE);
+        faultProvider.getDrivingFaults(data, TestCategory.BE);
         expect(catBEFaultProvider.getDrivingFaultsCatBE).toHaveBeenCalledWith(data);
       });
 
@@ -104,14 +101,14 @@ describe('fault-provider', () => {
           },
         };
 
-        faultProvider.getSeriousFaults(data, catB);
+        faultProvider.getSeriousFaults(data, TestCategory.B);
         expect(catBFaultProvider.getSeriousFaultsCatB).toHaveBeenCalledWith(data);
       });
 
       it('should call the cat be serious faults method when category is be', () => {
         spyOn(catBEFaultProvider, 'getSeriousFaultsCatBE');
         const data = {};
-        faultProvider.getSeriousFaults(data, catBE);
+        faultProvider.getSeriousFaults(data, TestCategory.BE);
         expect(catBEFaultProvider.getSeriousFaultsCatBE).toHaveBeenCalledWith(data);
       });
 
@@ -148,7 +145,7 @@ describe('fault-provider', () => {
           },
         };
 
-        faultProvider.getDangerousFaults(data, catB);
+        faultProvider.getDangerousFaults(data, TestCategory.B);
         expect(catBFaultProvider.getDangerousFaultsCatB).toHaveBeenCalledWith(data);
       });
 
@@ -176,7 +173,7 @@ describe('fault-provider', () => {
           },
         };
 
-        faultProvider.getDangerousFaults(data, catBE);
+        faultProvider.getDangerousFaults(data, TestCategory.BE);
         expect(catBEFaultProvider.getDangerousFaultsCatBE).toHaveBeenCalledWith(data);
       });
 

--- a/src/functions/sendCandidateResults/application/service/__tests__/template-id-provider.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/__tests__/template-id-provider.spec.ts
@@ -1,48 +1,138 @@
-import { TemplateIdProvider, isPass, isFail } from '../template-id-provider';
+import { TemplateIdProvider, isPass, isFail, isVocationalCategory, getTemplateString } from '../template-id-provider';
 import { ConfigAdapterMock } from '../../../framework/adapter/config/__mocks__/config-adapter.mock';
+import {
+  ActivityCode,
+  CommunicationMethod,
+  CommunicationPreferences,
+  ConductedLanguage,
+} from '@dvsa/mes-test-schema/categories/common';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+
+const communicationPreferences: CommunicationPreferences = {
+  updatedEmail: 'email@somewhere.com',
+  communicationMethod: 'Not provided',
+  conductedLanguage: 'Not provided',
+};
 
 describe('get-template-id-provider', () => {
-
   describe('TemplateIdProvider', () => {
-
     let templateIdProvider: TemplateIdProvider;
+
     beforeEach(() => {
       templateIdProvider = new TemplateIdProvider(new ConfigAdapterMock);
     });
 
-    describe('getEmailTemplateId', () => {
-      it('should return the english email pass template', () => {
-        expect(templateIdProvider.getEmailTemplateId('English', '1')).toBe('email-pass-template-id');
-      });
-      it('should return the english email fail template', () => {
-        expect(templateIdProvider.getEmailTemplateId('English', '2')).toBe('email-fail-template-id');
-      });
-      it('should return the welsh email pass template', () => {
-        expect(templateIdProvider.getEmailTemplateId('Cymraeg', '1')).toBe('email-welsh-pass-template-id');
-      });
-      it('should return the welsh email fail template', () => {
-        expect(templateIdProvider.getEmailTemplateId('Cymraeg', '2')).toBe('email-welsh-fail-template-id');
-      });
-      it('should return empty string for terminated tests', () => {
-        expect(templateIdProvider.getEmailTemplateId('English', '51')).toBe(TemplateIdProvider.TEMPLATE_ID_NOT_SET);
-      });
-    });
+    describe('getTemplateId', () => {
+      describe('English templates', () => {
+        beforeAll(() => {
+          communicationPreferences.conductedLanguage = 'English';
+        });
+        describe('Email', () => {
+          beforeAll(() => {
+            communicationPreferences.communicationMethod = 'Email';
+          });
+          it('should return the english email pass template', () => {
+            expect(templateIdProvider.getTemplateId(communicationPreferences, '1', TestCategory.B))
+              .toBe('email-english-pass-template-id');
+          });
+          it('should return the english email fail template', () => {
+            expect(templateIdProvider.getTemplateId(communicationPreferences, '2', TestCategory.BE))
+              .toBe('email-english-fail-template-id');
+          });
+          it('should return the english post pass template', () => {
+            expect(templateIdProvider.getTemplateId(communicationPreferences, '1', TestCategory.C))
+              .toBe('email-english-pass-template-id-vocational');
+          });
+          it('should return the english post fail template', () => {
+            expect(templateIdProvider.getTemplateId(communicationPreferences, '2', TestCategory.C1))
+              .toBe('email-english-fail-template-id-vocational');
+          });
+        });
 
-    describe('getLetterTemplateId', () => {
-      it('should return the english post pass template', () => {
-        expect(templateIdProvider.getLetterTemplateId('English', '1')).toBe('post-pass-template-id');
+        describe('Post', () => {
+          beforeAll(() => {
+            communicationPreferences.communicationMethod = 'Post';
+          });
+          it('should return the english post pass template', () => {
+            expect(templateIdProvider.getTemplateId(communicationPreferences, '1', TestCategory.B))
+              .toBe('post-english-pass-template-id');
+          });
+          it('should return the english post fail template', () => {
+            expect(templateIdProvider.getTemplateId(communicationPreferences, '2', TestCategory.BE))
+              .toBe('post-english-fail-template-id');
+          });
+          it('should return the english post pass template', () => {
+            expect(templateIdProvider.getTemplateId(communicationPreferences, '1', TestCategory.C))
+              .toBe('post-english-pass-template-id-vocational');
+          });
+          it('should return the english post fail template', () => {
+            expect(templateIdProvider.getTemplateId(communicationPreferences, '2', TestCategory.C1))
+              .toBe('post-english-fail-template-id-vocational');
+          });
+        });
       });
-      it('should return the english post fail template', () => {
-        expect(templateIdProvider.getLetterTemplateId('English', '2')).toBe('post-fail-template-id');
+
+      describe('Welsh templates', () => {
+        beforeAll(() => {
+          communicationPreferences.conductedLanguage = 'Cymraeg';
+        });
+
+        describe('Email', () => {
+          beforeAll(() => {
+            communicationPreferences.communicationMethod = 'Email';
+          });
+          it('should return the welsh email pass template', () => {
+            communicationPreferences.communicationMethod = 'Email';
+            expect(templateIdProvider.getTemplateId(communicationPreferences, '1', TestCategory.BE))
+              .toBe('email-welsh-pass-template-id');
+          });
+          it('should return the welsh email fail template', () => {
+            communicationPreferences.communicationMethod = 'Email';
+            expect(templateIdProvider.getTemplateId(communicationPreferences, '2', TestCategory.B))
+              .toBe('email-welsh-fail-template-id');
+          });
+          it('should return the welsh post pass template', () => {
+            communicationPreferences.communicationMethod = 'Email';
+            expect(templateIdProvider.getTemplateId(communicationPreferences, '1', TestCategory.CE))
+              .toBe('email-welsh-pass-template-id-vocational');
+          });
+          it('should return the welsh post fail template', () => {
+            communicationPreferences.communicationMethod = 'Email';
+            expect(templateIdProvider.getTemplateId(communicationPreferences, '2', TestCategory.C1E))
+              .toBe('email-welsh-fail-template-id-vocational');
+          });
+        });
+
+        describe('Post', () => {
+          beforeAll(() => {
+            communicationPreferences.communicationMethod = 'Post';
+          });
+          it('should return the welsh post pass template', () => {
+            communicationPreferences.communicationMethod = 'Post';
+            expect(templateIdProvider.getTemplateId(communicationPreferences, '1', TestCategory.BE))
+              .toBe('post-welsh-pass-template-id');
+          });
+          it('should return the welsh post fail template', () => {
+            communicationPreferences.communicationMethod = 'Post';
+            expect(templateIdProvider.getTemplateId(communicationPreferences, '2', TestCategory.B))
+              .toBe('post-welsh-fail-template-id');
+          });
+          it('should return the welsh post pass template', () => {
+            communicationPreferences.communicationMethod = 'Post';
+            expect(templateIdProvider.getTemplateId(communicationPreferences, '1', TestCategory.CE))
+              .toBe('post-welsh-pass-template-id-vocational');
+          });
+          it('should return the welsh post fail template', () => {
+            communicationPreferences.communicationMethod = 'Post';
+            expect(templateIdProvider.getTemplateId(communicationPreferences, '2', TestCategory.C1E))
+              .toBe('post-welsh-fail-template-id-vocational');
+          });
+        });
       });
-      it('should return the welsh post pass template', () => {
-        expect(templateIdProvider.getLetterTemplateId('Cymraeg', '1')).toBe('post-welsh-pass-template-id');
-      });
-      it('should return the welsh post fail template', () => {
-        expect(templateIdProvider.getLetterTemplateId('Cymraeg', '2')).toBe('post-welsh-fail-template-id');
-      });
-      it('should return empty string for terminated tests', () => {
-        expect(templateIdProvider.getLetterTemplateId('English', '51')).toBe(TemplateIdProvider.TEMPLATE_ID_NOT_SET);
+
+      it('should return ID not set string for terminated tests', () => {
+        expect(templateIdProvider.getTemplateId(communicationPreferences, '51', TestCategory.B))
+          .toBe(TemplateIdProvider.TEMPLATE_ID_NOT_SET);
       });
     });
   });
@@ -68,4 +158,69 @@ describe('get-template-id-provider', () => {
     });
   });
 
+  describe('isVocationalCategory', () => {
+    it('should return true if category is in vocational category array', () => {
+      expect(isVocationalCategory(TestCategory.C)).toBe(true);
+      expect(isVocationalCategory(TestCategory.C1)).toBe(true);
+      expect(isVocationalCategory(TestCategory.CE)).toBe(true);
+      expect(isVocationalCategory(TestCategory.C1E)).toBe(true);
+    });
+
+    it('should return false when category is not in the vocational category array', () => {
+      expect(isVocationalCategory(TestCategory.B)).toBe(false);
+      expect(isVocationalCategory(TestCategory.BE)).toBe(false);
+    });
+  });
+
+  describe('getTemplateString', () => {
+    it('should return true if category is in vocational category array', () => {
+      const conductedLanguage: ConductedLanguage = 'English';
+      const communicationMethod: CommunicationMethod = 'Email';
+      const activityCode: ActivityCode = '1';
+      expect(getTemplateString(conductedLanguage, communicationMethod, activityCode))
+        .toBe('englishEmailPassTemplateId');
+    });
+    it('should return true if category is in vocational category array', () => {
+      const conductedLanguage: ConductedLanguage = 'Cymraeg';
+      const communicationMethod: CommunicationMethod = 'Email';
+      const activityCode: ActivityCode = '1';
+      expect(getTemplateString(conductedLanguage, communicationMethod, activityCode))
+        .toBe('welshEmailPassTemplateId');
+    });
+    it('should return true if category is in vocational category array', () => {
+      const conductedLanguage: ConductedLanguage = 'English';
+      const communicationMethod: CommunicationMethod = 'Post';
+      const activityCode: ActivityCode = '1';
+      expect(getTemplateString(conductedLanguage, communicationMethod, activityCode))
+        .toBe('englishLetterPassTemplateId');
+    });
+    it('should return true if category is in vocational category array', () => {
+      const conductedLanguage: ConductedLanguage = 'Cymraeg';
+      const communicationMethod: CommunicationMethod = 'Post';
+      const activityCode: ActivityCode = '1';
+      expect(getTemplateString(conductedLanguage, communicationMethod, activityCode))
+        .toBe('welshLetterPassTemplateId');
+    });
+    it('should return true if category is in vocational category array', () => {
+      const conductedLanguage: ConductedLanguage = 'English';
+      const communicationMethod: CommunicationMethod = 'Email';
+      const activityCode: ActivityCode = '2';
+      expect(getTemplateString(conductedLanguage, communicationMethod, activityCode))
+        .toBe('englishEmailFailTemplateId');
+    });
+    it('should return true if category is in vocational category array', () => {
+      const conductedLanguage: ConductedLanguage = 'Cymraeg';
+      const communicationMethod: CommunicationMethod = 'Post';
+      const activityCode: ActivityCode = '2';
+      expect(getTemplateString(conductedLanguage, communicationMethod, activityCode))
+        .toBe('welshLetterFailTemplateId');
+    });
+    it('should return true if category is in vocational category array', () => {
+      const conductedLanguage: ConductedLanguage = 'English';
+      const communicationMethod: CommunicationMethod = 'Post';
+      const activityCode: ActivityCode = '51';
+      expect(getTemplateString(conductedLanguage, communicationMethod, activityCode))
+        .toBe('Template Id not set');
+    });
+  });
 });

--- a/src/functions/sendCandidateResults/application/service/__tests__/template-id-provider.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/__tests__/template-id-provider.spec.ts
@@ -173,49 +173,63 @@ describe('get-template-id-provider', () => {
   });
 
   describe('getTemplateString', () => {
-    it('should return true if category is in vocational category array', () => {
+    it('should return an english email pass template string', () => {
       const conductedLanguage: ConductedLanguage = 'English';
       const communicationMethod: CommunicationMethod = 'Email';
       const activityCode: ActivityCode = '1';
       expect(getTemplateString(conductedLanguage, communicationMethod, activityCode))
         .toBe('englishEmailPassTemplateId');
     });
-    it('should return true if category is in vocational category array', () => {
+    it('should return a welsh email pass template string', () => {
       const conductedLanguage: ConductedLanguage = 'Cymraeg';
       const communicationMethod: CommunicationMethod = 'Email';
       const activityCode: ActivityCode = '1';
       expect(getTemplateString(conductedLanguage, communicationMethod, activityCode))
         .toBe('welshEmailPassTemplateId');
     });
-    it('should return true if category is in vocational category array', () => {
+    it('should return an english letter pass template string', () => {
       const conductedLanguage: ConductedLanguage = 'English';
       const communicationMethod: CommunicationMethod = 'Post';
       const activityCode: ActivityCode = '1';
       expect(getTemplateString(conductedLanguage, communicationMethod, activityCode))
         .toBe('englishLetterPassTemplateId');
     });
-    it('should return true if category is in vocational category array', () => {
+    it('should return a welsh letter pass template string', () => {
       const conductedLanguage: ConductedLanguage = 'Cymraeg';
       const communicationMethod: CommunicationMethod = 'Post';
       const activityCode: ActivityCode = '1';
       expect(getTemplateString(conductedLanguage, communicationMethod, activityCode))
         .toBe('welshLetterPassTemplateId');
     });
-    it('should return true if category is in vocational category array', () => {
+    it('should return an english email fail template string', () => {
       const conductedLanguage: ConductedLanguage = 'English';
       const communicationMethod: CommunicationMethod = 'Email';
       const activityCode: ActivityCode = '2';
       expect(getTemplateString(conductedLanguage, communicationMethod, activityCode))
         .toBe('englishEmailFailTemplateId');
     });
-    it('should return true if category is in vocational category array', () => {
+    it('should return a welsh email fail template string', () => {
+      const conductedLanguage: ConductedLanguage = 'Cymraeg';
+      const communicationMethod: CommunicationMethod = 'Email';
+      const activityCode: ActivityCode = '2';
+      expect(getTemplateString(conductedLanguage, communicationMethod, activityCode))
+        .toBe('welshEmailFailTemplateId');
+    });
+    it('should return an english letter fail template string', () => {
+      const conductedLanguage: ConductedLanguage = 'English';
+      const communicationMethod: CommunicationMethod = 'Post';
+      const activityCode: ActivityCode = '2';
+      expect(getTemplateString(conductedLanguage, communicationMethod, activityCode))
+        .toBe('englishLetterFailTemplateId');
+    });
+    it('should return a welsh letter fail template string', () => {
       const conductedLanguage: ConductedLanguage = 'Cymraeg';
       const communicationMethod: CommunicationMethod = 'Post';
       const activityCode: ActivityCode = '2';
       expect(getTemplateString(conductedLanguage, communicationMethod, activityCode))
         .toBe('welshLetterFailTemplateId');
     });
-    it('should return true if category is in vocational category array', () => {
+    it('should return a template id not message set when activity code is 51', () => {
       const conductedLanguage: ConductedLanguage = 'English';
       const communicationMethod: CommunicationMethod = 'Post';
       const activityCode: ActivityCode = '51';

--- a/src/functions/sendCandidateResults/application/service/categories/C/__tests__/fault-provider-cat-c.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/C/__tests__/fault-provider-cat-c.spec.ts
@@ -1,0 +1,236 @@
+import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
+import { CompetencyOutcome } from '../../../../../domain/competency-outcome';
+import { Fault } from '../../../../../domain/fault';
+import {
+  getDangerousFaultsCatC,
+  getDrivingFaultsCatC,
+  getNonStandardFaultsCatC,
+  getSeriousFaultsCatC,
+  getVehicleChecksFaultCatC,
+} from '../fault-provider-cat-c';
+import { Competencies } from '../../../../../domain/competencies';
+
+describe('fault-provider-cat-c', () => {
+  describe('getVehicleChecksFaultCatC', () => {
+    it('should find a dangerous fault if one exists', () => {
+      const data: CatCUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.D,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatC(data, CompetencyOutcome.D);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should not find a dangerous fault if none exists', () => {
+      const data: CatCUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatC(data, CompetencyOutcome.D);
+      expect(result.length).toBe(0);
+    });
+
+    it('should find a serious fault if one exists', () => {
+      const data: CatCUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.S,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatC(data, CompetencyOutcome.S);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should not find a serious fault if none exist', () => {
+      const data: CatCUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatC(data, CompetencyOutcome.S);
+      expect(result.length).toBe(0);
+    });
+
+    it('should find a driving fault if one exists', () => {
+      const data: CatCUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatC(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should return a serious fault when 5 vehicle check driving faults', () => {
+      const vehicleChecks: CatCUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        },
+          {
+            code: 'S02',
+            description: 'S02',
+            outcome: CompetencyOutcome.DF,
+          },
+          {
+            code: 'S03',
+            description: 'S03',
+            outcome: CompetencyOutcome.DF,
+          }],
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        },
+          {
+            code: 'T02',
+            description: 'T02',
+            outcome: CompetencyOutcome.DF,
+          }],
+      };
+      const data: CatCUniqueTypes.TestData = {
+        vehicleChecks,
+        seriousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.S,
+          },
+        },
+      };
+      const result: Fault[] = getSeriousFaultsCatC(data);
+      expect(result.length).toBe(3);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+
+    it('should only return one driving fault with a count of two if two exist', () => {
+      const data: CatCUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+
+      const result: Fault[] = getVehicleChecksFaultCatC(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 2 });
+    });
+
+    it('should return one driving fault with a count of 1', () => {
+      const data: CatCUniqueTypes.VehicleChecks = {
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatC(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+  });
+
+  describe('getDangerousFaultsCatC', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatCUniqueTypes.TestData = {
+        dangerousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.D,
+          },
+        },
+      };
+      const result: Fault [] = getDangerousFaultsCatC(data);
+      expect(result.length).toBe(2);
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+  });
+
+  describe('getSeriousFaultsCatC', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatCUniqueTypes.TestData = {
+        seriousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.S,
+          },
+        },
+      };
+
+      const result: Fault [] = getSeriousFaultsCatC(data);
+      expect(result.length).toBe(2);
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+  });
+
+  describe('getDrivingFaultsCatC', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatCUniqueTypes.TestData = {
+        drivingFaults: {
+          ancillaryControls: 1,
+          awarenessPlanning: 0,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.DF,
+          },
+        },
+      };
+      const result: Fault [] = getDrivingFaultsCatC(data);
+
+      expect(result.length).toBe(2);
+      expect(result).toEqual([
+        { name: Competencies.ancillaryControls, count: 1 },
+        { name: Competencies.reverseLeftControl, count: 1 },
+      ]);
+    });
+  });
+
+  describe('getNonStandardFaultsCatC', () => {
+    it('should return an empty array when no faults recorded', () => {
+      const data: CatCUniqueTypes.TestData = {
+        vehicleChecks: {},
+        manoeuvres: {},
+      };
+      const result: Fault[] = getNonStandardFaultsCatC(data, CompetencyOutcome.DF);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/functions/sendCandidateResults/application/service/categories/C/fault-provider-cat-c.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/C/fault-provider-cat-c.ts
@@ -1,0 +1,119 @@
+import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
+import { Fault } from '../../../../domain/fault';
+import { CompetencyOutcome } from '../../../../domain/competency-outcome';
+import {
+  convertBooleanFaultObjectToArray,
+  convertNumericFaultObjectToArray,
+  getCompletedManoeuvres,
+} from '../../fault-provider';
+import { Competencies } from '../../../../domain/competencies';
+import { QuestionOutcome, QuestionResult } from '@dvsa/mes-test-schema/categories/common';
+
+export const getDrivingFaultsCatC = (testData: CatCUniqueTypes.TestData | undefined): Fault [] => {
+  const drivingFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.drivingFaults) {
+    convertNumericFaultObjectToArray(testData.drivingFaults)
+      .forEach(fault => drivingFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatC(testData, CompetencyOutcome.DF)
+    .forEach(fault => drivingFaults.push(fault));
+
+  return drivingFaults;
+};
+
+export const getSeriousFaultsCatC = (testData: CatCUniqueTypes.TestData | undefined): Fault [] => {
+  const seriousFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.seriousFaults) {
+    convertBooleanFaultObjectToArray(testData.seriousFaults)
+      .forEach(fault => seriousFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatC(testData, CompetencyOutcome.S)
+    .forEach(fault => seriousFaults.push(fault));
+
+  if (getVehicleCheckFaultCount(testData.vehicleChecks as CatCUniqueTypes.VehicleChecks, CompetencyOutcome.DF) === 5) {
+    seriousFaults.push({ name: Competencies.vehicleChecks, count: 1 });
+  }
+
+  return seriousFaults;
+};
+
+const getVehicleCheckFaultCount = (
+  vehicleChecks: CatCUniqueTypes.VehicleChecks,
+  faultType: QuestionOutcome): number => {
+  let questionCount: number = 0;
+
+  if (vehicleChecks) {
+    if (vehicleChecks.showMeQuestions) {
+      questionCount = questionCount +
+        vehicleChecks.showMeQuestions.filter((showMe: QuestionResult) => showMe.outcome === faultType).length;
+    }
+    if (vehicleChecks.tellMeQuestions) {
+      questionCount = questionCount +
+        vehicleChecks.tellMeQuestions.filter((tellMe: QuestionResult) => tellMe.outcome === faultType).length;
+    }
+  }
+  return questionCount;
+};
+
+export const getDangerousFaultsCatC = (testData: CatCUniqueTypes.TestData | undefined): Fault [] => {
+  const dangerousFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.dangerousFaults) {
+    convertBooleanFaultObjectToArray(testData.dangerousFaults)
+      .forEach(fault => dangerousFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatC(testData, CompetencyOutcome.D)
+    .forEach(fault => dangerousFaults.push(fault));
+
+  return dangerousFaults;
+};
+
+export const getNonStandardFaultsCatC = (
+  testData: CatCUniqueTypes.TestData,
+  faultType: CompetencyOutcome): Fault[] => {
+
+  const faults: Fault[] = [];
+
+// Manoeuvres
+  if (testData.manoeuvres) {
+    getCompletedManoeuvres(testData.manoeuvres, faultType)
+      .forEach(fault => faults.push(fault));
+  }
+
+// Vehicle Checks
+  if (testData.vehicleChecks) {
+    getVehicleChecksFaultCatC(testData.vehicleChecks, faultType)
+      .forEach(fault => faults.push(fault));
+  }
+
+  return faults;
+};
+
+export const getVehicleChecksFaultCatC = (
+  vehicleChecks: CatCUniqueTypes.VehicleChecks,
+  faultType: QuestionOutcome): Fault[] => {
+  const faultArray: Fault[] = [];
+  const faultCount = getVehicleCheckFaultCount(vehicleChecks, faultType);
+
+  if (faultCount > 0) {
+    faultArray.push({ name: Competencies.vehicleChecks, count: faultCount === 5 ? 4 : faultCount });
+  }
+  return faultArray;
+};

--- a/src/functions/sendCandidateResults/application/service/categories/C/fault-provider-cat-c.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/C/fault-provider-cat-c.ts
@@ -1,5 +1,5 @@
 import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
-import { Fault } from '../../../../domain/fault';
+import { Fault, vehicleCheckDrivingFaultLimit } from '../../../../domain/fault';
 import { CompetencyOutcome } from '../../../../domain/competency-outcome';
 import {
   convertBooleanFaultObjectToArray,
@@ -42,7 +42,8 @@ export const getSeriousFaultsCatC = (testData: CatCUniqueTypes.TestData | undefi
   getNonStandardFaultsCatC(testData, CompetencyOutcome.S)
     .forEach(fault => seriousFaults.push(fault));
 
-  if (getVehicleCheckFaultCount(testData.vehicleChecks as CatCUniqueTypes.VehicleChecks, CompetencyOutcome.DF) === 5) {
+  if (getVehicleCheckFaultCount(testData.vehicleChecks as CatCUniqueTypes.VehicleChecks, CompetencyOutcome.DF) ===
+    vehicleCheckDrivingFaultLimit) {
     seriousFaults.push({ name: Competencies.vehicleChecks, count: 1 });
   }
 
@@ -54,15 +55,17 @@ const getVehicleCheckFaultCount = (
   faultType: QuestionOutcome): number => {
   let questionCount: number = 0;
 
-  if (vehicleChecks) {
-    if (vehicleChecks.showMeQuestions) {
-      questionCount = questionCount +
+  if (!vehicleChecks) {
+    return questionCount;
+  }
+
+  if (vehicleChecks.showMeQuestions) {
+    questionCount = questionCount +
         vehicleChecks.showMeQuestions.filter((showMe: QuestionResult) => showMe.outcome === faultType).length;
-    }
-    if (vehicleChecks.tellMeQuestions) {
-      questionCount = questionCount +
+  }
+  if (vehicleChecks.tellMeQuestions) {
+    questionCount = questionCount +
         vehicleChecks.tellMeQuestions.filter((tellMe: QuestionResult) => tellMe.outcome === faultType).length;
-    }
   }
   return questionCount;
 };
@@ -113,7 +116,9 @@ export const getVehicleChecksFaultCatC = (
   const faultCount = getVehicleCheckFaultCount(vehicleChecks, faultType);
 
   if (faultCount > 0) {
-    faultArray.push({ name: Competencies.vehicleChecks, count: faultCount === 5 ? 4 : faultCount });
+    faultArray.push(
+      { name: Competencies.vehicleChecks, count: faultCount === vehicleCheckDrivingFaultLimit ? 4 : faultCount },
+    );
   }
   return faultArray;
 };

--- a/src/functions/sendCandidateResults/application/service/categories/C1/__tests__/fault-provider-cat-c1.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/C1/__tests__/fault-provider-cat-c1.spec.ts
@@ -1,0 +1,236 @@
+import { CatC1UniqueTypes } from '@dvsa/mes-test-schema/categories/C1';
+import { CompetencyOutcome } from '../../../../../domain/competency-outcome';
+import { Fault } from '../../../../../domain/fault';
+import {
+  getDangerousFaultsCatC1,
+  getDrivingFaultsCatC1,
+  getNonStandardFaultsCatC1,
+  getSeriousFaultsCatC1,
+  getVehicleChecksFaultCatC1,
+} from '../fault-provider-cat-c1';
+import { Competencies } from '../../../../../domain/competencies';
+
+describe('fault-provider-cat-c1', () => {
+  describe('getVehicleChecksFaultCatC1', () => {
+    it('should find a dangerous fault if one exists', () => {
+      const data: CatC1UniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.D,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatC1(data, CompetencyOutcome.D);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should not find a dangerous fault if none exists', () => {
+      const data: CatC1UniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatC1(data, CompetencyOutcome.D);
+      expect(result.length).toBe(0);
+    });
+
+    it('should find a serious fault if one exists', () => {
+      const data: CatC1UniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.S,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatC1(data, CompetencyOutcome.S);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should not find a serious fault if none exist', () => {
+      const data: CatC1UniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatC1(data, CompetencyOutcome.S);
+      expect(result.length).toBe(0);
+    });
+
+    it('should find a driving fault if one exists', () => {
+      const data: CatC1UniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatC1(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should return a serious fault when 5 vehicle check driving faults', () => {
+      const vehicleChecks: CatC1UniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        },
+          {
+            code: 'S02',
+            description: 'S02',
+            outcome: CompetencyOutcome.DF,
+          },
+          {
+            code: 'S03',
+            description: 'S03',
+            outcome: CompetencyOutcome.DF,
+          }],
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        },
+          {
+            code: 'T02',
+            description: 'T02',
+            outcome: CompetencyOutcome.DF,
+          }],
+      };
+      const data: CatC1UniqueTypes.TestData = {
+        vehicleChecks,
+        seriousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.S,
+          },
+        },
+      };
+      const result: Fault[] = getSeriousFaultsCatC1(data);
+      expect(result.length).toBe(3);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+
+    it('should only return one driving fault with a count of two if two exist', () => {
+      const data: CatC1UniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+
+      const result: Fault[] = getVehicleChecksFaultCatC1(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 2 });
+    });
+
+    it('should return one driving fault with a count of 1', () => {
+      const data: CatC1UniqueTypes.VehicleChecks = {
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatC1(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+  });
+
+  describe('getDangerousFaultsCatC1', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatC1UniqueTypes.TestData = {
+        dangerousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.D,
+          },
+        },
+      };
+      const result: Fault [] = getDangerousFaultsCatC1(data);
+      expect(result.length).toBe(2);
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+  });
+
+  describe('getSeriousFaultsCatC1', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatC1UniqueTypes.TestData = {
+        seriousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.S,
+          },
+        },
+      };
+
+      const result: Fault [] = getSeriousFaultsCatC1(data);
+      expect(result.length).toBe(2);
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+  });
+
+  describe('getDrivingFaultsCatC1', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatC1UniqueTypes.TestData = {
+        drivingFaults: {
+          ancillaryControls: 1,
+          awarenessPlanning: 0,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.DF,
+          },
+        },
+      };
+      const result: Fault [] = getDrivingFaultsCatC1(data);
+
+      expect(result.length).toBe(2);
+      expect(result).toEqual([
+        { name: Competencies.ancillaryControls, count: 1 },
+        { name: Competencies.reverseLeftControl, count: 1 },
+      ]);
+    });
+  });
+
+  describe('getNonStandardFaultsCatC1', () => {
+    it('should return an empty array when no faults recorded', () => {
+      const data: CatC1UniqueTypes.TestData = {
+        vehicleChecks: {},
+        manoeuvres: {},
+      };
+      const result: Fault[] = getNonStandardFaultsCatC1(data, CompetencyOutcome.DF);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/functions/sendCandidateResults/application/service/categories/C1/fault-provider-cat-c1.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/C1/fault-provider-cat-c1.ts
@@ -1,0 +1,119 @@
+import { CatC1UniqueTypes } from '@dvsa/mes-test-schema/categories/C1';
+import { QuestionOutcome, QuestionResult } from '@dvsa/mes-test-schema/categories/common';
+import { Fault } from '../../../../domain/fault';
+import { CompetencyOutcome } from '../../../../domain/competency-outcome';
+import {
+  convertBooleanFaultObjectToArray,
+  convertNumericFaultObjectToArray,
+  getCompletedManoeuvres,
+} from '../../fault-provider';
+import { Competencies } from '../../../../domain/competencies';
+
+export const getDrivingFaultsCatC1 = (testData: CatC1UniqueTypes.TestData | undefined): Fault [] => {
+  const drivingFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.drivingFaults) {
+    convertNumericFaultObjectToArray(testData.drivingFaults)
+      .forEach(fault => drivingFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatC1(testData, CompetencyOutcome.DF)
+    .forEach(fault => drivingFaults.push(fault));
+
+  return drivingFaults;
+};
+
+export const getSeriousFaultsCatC1 = (testData: CatC1UniqueTypes.TestData | undefined): Fault [] => {
+  const seriousFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.seriousFaults) {
+    convertBooleanFaultObjectToArray(testData.seriousFaults)
+      .forEach(fault => seriousFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatC1(testData, CompetencyOutcome.S)
+    .forEach(fault => seriousFaults.push(fault));
+
+  if (getVehicleCheckFaultCount(testData.vehicleChecks as CatC1UniqueTypes.VehicleChecks, CompetencyOutcome.DF) === 5) {
+    seriousFaults.push({ name: Competencies.vehicleChecks, count: 1 });
+  }
+
+  return seriousFaults;
+};
+
+const getVehicleCheckFaultCount = (
+  vehicleChecks: CatC1UniqueTypes.VehicleChecks,
+  faultType: QuestionOutcome): number => {
+  let questionCount: number = 0;
+
+  if (vehicleChecks) {
+    if (vehicleChecks.showMeQuestions) {
+      questionCount = questionCount +
+        vehicleChecks.showMeQuestions.filter((showMe: QuestionResult) => showMe.outcome === faultType).length;
+    }
+    if (vehicleChecks.tellMeQuestions) {
+      questionCount = questionCount +
+        vehicleChecks.tellMeQuestions.filter((tellMe: QuestionResult) => tellMe.outcome === faultType).length;
+    }
+  }
+  return questionCount;
+};
+
+export const getDangerousFaultsCatC1 = (testData: CatC1UniqueTypes.TestData | undefined): Fault [] => {
+  const dangerousFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.dangerousFaults) {
+    convertBooleanFaultObjectToArray(testData.dangerousFaults)
+      .forEach(fault => dangerousFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatC1(testData, CompetencyOutcome.D)
+    .forEach(fault => dangerousFaults.push(fault));
+
+  return dangerousFaults;
+};
+
+export const getNonStandardFaultsCatC1 = (
+  testData: CatC1UniqueTypes.TestData,
+  faultType: CompetencyOutcome): Fault[] => {
+
+  const faults: Fault[] = [];
+
+// Manoeuvres
+  if (testData.manoeuvres) {
+    getCompletedManoeuvres(testData.manoeuvres, faultType)
+      .forEach(fault => faults.push(fault));
+  }
+
+// Vehicle Checks
+  if (testData.vehicleChecks) {
+    getVehicleChecksFaultCatC1(testData.vehicleChecks, faultType)
+      .forEach(fault => faults.push(fault));
+  }
+
+  return faults;
+};
+
+export const getVehicleChecksFaultCatC1 = (
+  vehicleChecks: CatC1UniqueTypes.VehicleChecks,
+  faultType: QuestionOutcome): Fault[] => {
+  const faultArray: Fault[] = [];
+  const faultCount = getVehicleCheckFaultCount(vehicleChecks, faultType);
+
+  if (faultCount > 0) {
+    faultArray.push({ name: Competencies.vehicleChecks, count: faultCount === 5 ? 4 : faultCount });
+  }
+  return faultArray;
+};

--- a/src/functions/sendCandidateResults/application/service/categories/C1E/__tests__/fault-provider-cat-c1e.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/C1E/__tests__/fault-provider-cat-c1e.spec.ts
@@ -1,0 +1,253 @@
+import { CatC1EUniqueTypes } from '@dvsa/mes-test-schema/categories/C1E';
+import { CompetencyOutcome } from '../../../../../domain/competency-outcome';
+import { Fault } from '../../../../../domain/fault';
+import {
+  getDangerousFaultsCatC1E,
+  getDrivingFaultsCatC1E,
+  getNonStandardFaultsCatC1E,
+  getSeriousFaultsCatC1E,
+  getVehicleChecksFaultCatC1E,
+} from '../fault-provider-cat-c1e';
+import { Competencies } from '../../../../../domain/competencies';
+
+describe('fault-provider-cat-c1e', () => {
+  describe('getVehicleChecksFaultCatC1E', () => {
+    it('should find a dangerous fault if one exists', () => {
+      const data: CatC1EUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.D,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatC1E(data, CompetencyOutcome.D);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should not find a dangerous fault if none exists', () => {
+      const data: CatC1EUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatC1E(data, CompetencyOutcome.D);
+      expect(result.length).toBe(0);
+    });
+
+    it('should find a serious fault if one exists', () => {
+      const data: CatC1EUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.S,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatC1E(data, CompetencyOutcome.S);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should not find a serious fault if none exist', () => {
+      const data: CatC1EUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatC1E(data, CompetencyOutcome.S);
+      expect(result.length).toBe(0);
+    });
+
+    it('should find a driving fault if one exists', () => {
+      const data: CatC1EUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatC1E(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should return a serious fault when 5 vehicle check driving faults', () => {
+      const vehicleChecks: CatC1EUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        },
+          {
+            code: 'S02',
+            description: 'S02',
+            outcome: CompetencyOutcome.DF,
+          },
+          {
+            code: 'S03',
+            description: 'S03',
+            outcome: CompetencyOutcome.DF,
+          }],
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        },
+          {
+            code: 'T02',
+            description: 'T02',
+            outcome: CompetencyOutcome.DF,
+          }],
+      };
+      const data: CatC1EUniqueTypes.TestData = {
+        vehicleChecks,
+        seriousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.S,
+          },
+        },
+      };
+      const result: Fault[] = getSeriousFaultsCatC1E(data);
+      expect(result.length).toBe(3);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+
+    it('should only return one driving fault with a count of two if two exist', () => {
+      const data: CatC1EUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+
+      const result: Fault[] = getVehicleChecksFaultCatC1E(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 2 });
+    });
+
+    it('should return one driving fault with a count of 1', () => {
+      const data: CatC1EUniqueTypes.VehicleChecks = {
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatC1E(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+  });
+
+  describe('getDangerousFaultsCatC1E', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatC1EUniqueTypes.TestData = {
+        dangerousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.D,
+          },
+        },
+      };
+      const result: Fault [] = getDangerousFaultsCatC1E(data);
+      expect(result.length).toBe(2);
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+  });
+
+  describe('getSeriousFaultsCatC1E', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatC1EUniqueTypes.TestData = {
+        seriousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.S,
+          },
+        },
+      };
+
+      const result: Fault [] = getSeriousFaultsCatC1E(data);
+      expect(result.length).toBe(2);
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+  });
+
+  describe('getDrivingFaultsCatC1E', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatC1EUniqueTypes.TestData = {
+        drivingFaults: {
+          ancillaryControls: 1,
+          awarenessPlanning: 0,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.DF,
+          },
+        },
+      };
+      const result: Fault [] = getDrivingFaultsCatC1E(data);
+
+      expect(result.length).toBe(2);
+      expect(result).toEqual([
+        { name: Competencies.ancillaryControls, count: 1 },
+        { name: Competencies.reverseLeftControl, count: 1 },
+      ]);
+    });
+  });
+
+  describe('getNonStandardFaultsCatC1E', () => {
+    it('should return the uncouple competency when fault type is same to fault passed in and it was selected', () => {
+      const data: CatC1EUniqueTypes.TestData = {
+        uncoupleRecouple: {
+          fault: 'DF',
+          faultComments: 'some comment',
+          selected: true,
+        },
+        vehicleChecks: {},
+        manoeuvres: {},
+      };
+      const result: Fault[] = getNonStandardFaultsCatC1E(data, CompetencyOutcome.DF);
+      expect(result).toContain({ name: Competencies.uncoupleRecouple, count: 1 });
+    });
+
+    it('should return an empty array when the selected value is false', () => {
+      const data: CatC1EUniqueTypes.TestData = {
+        uncoupleRecouple: {
+          fault: 'DF',
+          faultComments: 'some comment',
+          selected: false,
+        },
+      };
+      const result: Fault[] = getNonStandardFaultsCatC1E(data, CompetencyOutcome.DF);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/functions/sendCandidateResults/application/service/categories/C1E/fault-provider-cat-c1e.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/C1E/fault-provider-cat-c1e.ts
@@ -1,0 +1,128 @@
+import { CatC1EUniqueTypes } from '@dvsa/mes-test-schema/categories/C1E';
+import { QuestionOutcome, QuestionResult } from '@dvsa/mes-test-schema/categories/common';
+import { Fault } from '../../../../domain/fault';
+import { CompetencyOutcome } from '../../../../domain/competency-outcome';
+import {
+  convertBooleanFaultObjectToArray,
+  convertNumericFaultObjectToArray,
+  getCompletedManoeuvres,
+} from '../../fault-provider';
+import { Competencies } from '../../../../domain/competencies';
+
+export const getDrivingFaultsCatC1E = (testData: CatC1EUniqueTypes.TestData | undefined): Fault [] => {
+  const drivingFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.drivingFaults) {
+    convertNumericFaultObjectToArray(testData.drivingFaults)
+      .forEach(fault => drivingFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatC1E(testData, CompetencyOutcome.DF)
+    .forEach(fault => drivingFaults.push(fault));
+
+  return drivingFaults;
+};
+
+export const getSeriousFaultsCatC1E = (testData: CatC1EUniqueTypes.TestData | undefined): Fault [] => {
+  const seriousFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.seriousFaults) {
+    convertBooleanFaultObjectToArray(testData.seriousFaults)
+      .forEach(fault => seriousFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatC1E(testData, CompetencyOutcome.S)
+    .forEach(fault => seriousFaults.push(fault));
+
+  if (
+    getVehicleCheckFaultCount(testData.vehicleChecks as CatC1EUniqueTypes.VehicleChecks, CompetencyOutcome.DF) === 5) {
+    seriousFaults.push({ name: Competencies.vehicleChecks, count: 1 });
+  }
+
+  return seriousFaults;
+};
+
+const getVehicleCheckFaultCount = (
+  vehicleChecks: CatC1EUniqueTypes.VehicleChecks,
+  faultType: QuestionOutcome): number => {
+  let questionCount: number = 0;
+
+  if (vehicleChecks) {
+    if (vehicleChecks.showMeQuestions) {
+      questionCount = questionCount +
+        vehicleChecks.showMeQuestions.filter((showMe: QuestionResult) => showMe.outcome === faultType).length;
+    }
+    if (vehicleChecks.tellMeQuestions) {
+      questionCount = questionCount +
+        vehicleChecks.tellMeQuestions.filter((tellMe: QuestionResult) => tellMe.outcome === faultType).length;
+    }
+  }
+  return questionCount;
+};
+
+export const getDangerousFaultsCatC1E = (testData: CatC1EUniqueTypes.TestData | undefined): Fault [] => {
+  const dangerousFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.dangerousFaults) {
+    convertBooleanFaultObjectToArray(testData.dangerousFaults)
+      .forEach(fault => dangerousFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatC1E(testData, CompetencyOutcome.D)
+    .forEach(fault => dangerousFaults.push(fault));
+
+  return dangerousFaults;
+};
+
+export const getNonStandardFaultsCatC1E = (
+  testData: CatC1EUniqueTypes.TestData,
+  faultType: CompetencyOutcome): Fault[] => {
+
+  const faults: Fault[] = [];
+
+// Uncouple / recouple
+  if (
+    testData.uncoupleRecouple &&
+    testData.uncoupleRecouple.selected &&
+    testData.uncoupleRecouple.fault === faultType) {
+    faults.push({ name: Competencies.uncoupleRecouple, count: 1 });
+  }
+
+// Manoeuvres
+  if (testData.manoeuvres) {
+    getCompletedManoeuvres(testData.manoeuvres, faultType)
+      .forEach(fault => faults.push(fault));
+  }
+
+// Vehicle Checks
+  if (testData.vehicleChecks) {
+    getVehicleChecksFaultCatC1E(testData.vehicleChecks, faultType)
+      .forEach(fault => faults.push(fault));
+  }
+
+  return faults;
+};
+
+export const getVehicleChecksFaultCatC1E = (
+  vehicleChecks: CatC1EUniqueTypes.VehicleChecks,
+  faultType: QuestionOutcome): Fault[] => {
+  const faultArray: Fault[] = [];
+  const faultCount = getVehicleCheckFaultCount(vehicleChecks, faultType);
+
+  if (faultCount > 0) {
+    faultArray.push({ name: Competencies.vehicleChecks, count: faultCount === 5 ? 4 : faultCount });
+  }
+  return faultArray;
+};

--- a/src/functions/sendCandidateResults/application/service/categories/CE/__tests__/fault-provider-cat-ce.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/CE/__tests__/fault-provider-cat-ce.spec.ts
@@ -1,0 +1,253 @@
+import { CatCEUniqueTypes } from '@dvsa/mes-test-schema/categories/CE';
+import { CompetencyOutcome } from '../../../../../domain/competency-outcome';
+import { Fault } from '../../../../../domain/fault';
+import {
+  getDangerousFaultsCatCE,
+  getDrivingFaultsCatCE,
+  getNonStandardFaultsCatCE,
+  getSeriousFaultsCatCE,
+  getVehicleChecksFaultCatCE,
+} from '../fault-provider-cat-ce';
+import { Competencies } from '../../../../../domain/competencies';
+
+describe('fault-provider-cat-ce', () => {
+  describe('getVehicleChecksFaultCatCE', () => {
+    it('should find a dangerous fault if one exists', () => {
+      const data: CatCEUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.D,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatCE(data, CompetencyOutcome.D);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should not find a dangerous fault if none exists', () => {
+      const data: CatCEUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatCE(data, CompetencyOutcome.D);
+      expect(result.length).toBe(0);
+    });
+
+    it('should find a serious fault if one exists', () => {
+      const data: CatCEUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.S,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatCE(data, CompetencyOutcome.S);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should not find a serious fault if none exist', () => {
+      const data: CatCEUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatCE(data, CompetencyOutcome.S);
+      expect(result.length).toBe(0);
+    });
+
+    it('should find a driving fault if one exists', () => {
+      const data: CatCEUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatCE(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should return a serious fault when 5 vehicle check driving faults', () => {
+      const vehicleChecks: CatCEUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        },
+          {
+            code: 'S02',
+            description: 'S02',
+            outcome: CompetencyOutcome.DF,
+          },
+          {
+            code: 'S03',
+            description: 'S03',
+            outcome: CompetencyOutcome.DF,
+          }],
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        },
+          {
+            code: 'T02',
+            description: 'T02',
+            outcome: CompetencyOutcome.DF,
+          }],
+      };
+      const data: CatCEUniqueTypes.TestData = {
+        vehicleChecks,
+        seriousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.S,
+          },
+        },
+      };
+      const result: Fault[] = getSeriousFaultsCatCE(data);
+      expect(result.length).toBe(3);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+
+    it('should only return one driving fault with a count of two if two exist', () => {
+      const data: CatCEUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+
+      const result: Fault[] = getVehicleChecksFaultCatCE(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 2 });
+    });
+
+    it('should return one driving fault with a count of 1', () => {
+      const data: CatCEUniqueTypes.VehicleChecks = {
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatCE(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+  });
+
+  describe('getDangerousFaultsCatCE', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatCEUniqueTypes.TestData = {
+        dangerousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.D,
+          },
+        },
+      };
+      const result: Fault [] = getDangerousFaultsCatCE(data);
+      expect(result.length).toBe(2);
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+  });
+
+  describe('getSeriousFaultsCatCE', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatCEUniqueTypes.TestData = {
+        seriousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.S,
+          },
+        },
+      };
+
+      const result: Fault [] = getSeriousFaultsCatCE(data);
+      expect(result.length).toBe(2);
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+  });
+
+  describe('getDrivingFaultsCatCE', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatCEUniqueTypes.TestData = {
+        drivingFaults: {
+          ancillaryControls: 1,
+          awarenessPlanning: 0,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.DF,
+          },
+        },
+      };
+      const result: Fault [] = getDrivingFaultsCatCE(data);
+
+      expect(result.length).toBe(2);
+      expect(result).toEqual([
+        { name: Competencies.ancillaryControls, count: 1 },
+        { name: Competencies.reverseLeftControl, count: 1 },
+      ]);
+    });
+  });
+
+  describe('getNonStandardFaultsCatCE', () => {
+    it('should return the uncouple competency when fault type is same to fault passed in and it was selected', () => {
+      const data: CatCEUniqueTypes.TestData = {
+        uncoupleRecouple: {
+          fault: 'DF',
+          faultComments: 'some comment',
+          selected: true,
+        },
+        vehicleChecks: {},
+        manoeuvres: {},
+      };
+      const result: Fault[] = getNonStandardFaultsCatCE(data, CompetencyOutcome.DF);
+      expect(result).toContain({ name: Competencies.uncoupleRecouple, count: 1 });
+    });
+
+    it('should return an empty array when the selected value is false', () => {
+      const data: CatCEUniqueTypes.TestData = {
+        uncoupleRecouple: {
+          fault: 'DF',
+          faultComments: 'some comment',
+          selected: false,
+        },
+      };
+      const result: Fault[] = getNonStandardFaultsCatCE(data, CompetencyOutcome.DF);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/functions/sendCandidateResults/application/service/categories/CE/fault-provider-cat-ce.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/CE/fault-provider-cat-ce.ts
@@ -1,0 +1,127 @@
+import { CatCEUniqueTypes } from '@dvsa/mes-test-schema/categories/CE';
+import { QuestionOutcome, QuestionResult } from '@dvsa/mes-test-schema/categories/common';
+import { Fault } from '../../../../domain/fault';
+import { CompetencyOutcome } from '../../../../domain/competency-outcome';
+import {
+  convertBooleanFaultObjectToArray,
+  convertNumericFaultObjectToArray,
+  getCompletedManoeuvres,
+} from '../../fault-provider';
+import { Competencies } from '../../../../domain/competencies';
+
+export const getDrivingFaultsCatCE = (testData: CatCEUniqueTypes.TestData | undefined): Fault [] => {
+  const drivingFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.drivingFaults) {
+    convertNumericFaultObjectToArray(testData.drivingFaults)
+      .forEach(fault => drivingFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatCE(testData, CompetencyOutcome.DF)
+    .forEach(fault => drivingFaults.push(fault));
+
+  return drivingFaults;
+};
+
+export const getSeriousFaultsCatCE = (testData: CatCEUniqueTypes.TestData | undefined): Fault [] => {
+  const seriousFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.seriousFaults) {
+    convertBooleanFaultObjectToArray(testData.seriousFaults)
+      .forEach(fault => seriousFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatCE(testData, CompetencyOutcome.S)
+    .forEach(fault => seriousFaults.push(fault));
+
+  if (getVehicleCheckFaultCount(testData.vehicleChecks as CatCEUniqueTypes.VehicleChecks, CompetencyOutcome.DF) === 5) {
+    seriousFaults.push({ name: Competencies.vehicleChecks, count: 1 });
+  }
+
+  return seriousFaults;
+};
+
+const getVehicleCheckFaultCount = (
+  vehicleChecks: CatCEUniqueTypes.VehicleChecks,
+  faultType: QuestionOutcome): number => {
+  let questionCount: number = 0;
+
+  if (vehicleChecks) {
+    if (vehicleChecks.showMeQuestions) {
+      questionCount = questionCount +
+        vehicleChecks.showMeQuestions.filter((showMe: QuestionResult) => showMe.outcome === faultType).length;
+    }
+    if (vehicleChecks.tellMeQuestions) {
+      questionCount = questionCount +
+        vehicleChecks.tellMeQuestions.filter((tellMe: QuestionResult) => tellMe.outcome === faultType).length;
+    }
+  }
+  return questionCount;
+};
+
+export const getDangerousFaultsCatCE = (testData: CatCEUniqueTypes.TestData | undefined): Fault [] => {
+  const dangerousFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.dangerousFaults) {
+    convertBooleanFaultObjectToArray(testData.dangerousFaults)
+      .forEach(fault => dangerousFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatCE(testData, CompetencyOutcome.D)
+    .forEach(fault => dangerousFaults.push(fault));
+
+  return dangerousFaults;
+};
+
+export const getNonStandardFaultsCatCE = (
+  testData: CatCEUniqueTypes.TestData,
+  faultType: CompetencyOutcome): Fault[] => {
+
+  const faults: Fault[] = [];
+
+// Uncouple / recouple
+  if (
+    testData.uncoupleRecouple &&
+    testData.uncoupleRecouple.selected &&
+    testData.uncoupleRecouple.fault === faultType) {
+    faults.push({ name: Competencies.uncoupleRecouple, count: 1 });
+  }
+
+// Manoeuvres
+  if (testData.manoeuvres) {
+    getCompletedManoeuvres(testData.manoeuvres, faultType)
+      .forEach(fault => faults.push(fault));
+  }
+
+// Vehicle Checks
+  if (testData.vehicleChecks) {
+    getVehicleChecksFaultCatCE(testData.vehicleChecks, faultType)
+      .forEach(fault => faults.push(fault));
+  }
+
+  return faults;
+};
+
+export const getVehicleChecksFaultCatCE = (
+  vehicleChecks: CatCEUniqueTypes.VehicleChecks,
+  faultType: QuestionOutcome): Fault[] => {
+  const faultArray: Fault[] = [];
+  const faultCount = getVehicleCheckFaultCount(vehicleChecks, faultType);
+
+  if (faultCount > 0) {
+    faultArray.push({ name: Competencies.vehicleChecks, count: faultCount === 5 ? 4 : faultCount });
+  }
+  return faultArray;
+};

--- a/src/functions/sendCandidateResults/application/service/categories/CE/fault-provider-cat-ce.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/CE/fault-provider-cat-ce.ts
@@ -1,6 +1,6 @@
 import { CatCEUniqueTypes } from '@dvsa/mes-test-schema/categories/CE';
 import { QuestionOutcome, QuestionResult } from '@dvsa/mes-test-schema/categories/common';
-import { Fault } from '../../../../domain/fault';
+import { Fault, vehicleCheckDrivingFaultLimit } from '../../../../domain/fault';
 import { CompetencyOutcome } from '../../../../domain/competency-outcome';
 import {
   convertBooleanFaultObjectToArray,
@@ -42,7 +42,8 @@ export const getSeriousFaultsCatCE = (testData: CatCEUniqueTypes.TestData | unde
   getNonStandardFaultsCatCE(testData, CompetencyOutcome.S)
     .forEach(fault => seriousFaults.push(fault));
 
-  if (getVehicleCheckFaultCount(testData.vehicleChecks as CatCEUniqueTypes.VehicleChecks, CompetencyOutcome.DF) === 5) {
+  if (getVehicleCheckFaultCount(testData.vehicleChecks as CatCEUniqueTypes.VehicleChecks, CompetencyOutcome.DF) ===
+    vehicleCheckDrivingFaultLimit) {
     seriousFaults.push({ name: Competencies.vehicleChecks, count: 1 });
   }
 
@@ -121,7 +122,9 @@ export const getVehicleChecksFaultCatCE = (
   const faultCount = getVehicleCheckFaultCount(vehicleChecks, faultType);
 
   if (faultCount > 0) {
-    faultArray.push({ name: Competencies.vehicleChecks, count: faultCount === 5 ? 4 : faultCount });
+    faultArray.push(
+      { name: Competencies.vehicleChecks, count: faultCount === vehicleCheckDrivingFaultLimit ? 4 : faultCount },
+    );
   }
   return faultArray;
 };

--- a/src/functions/sendCandidateResults/application/service/fault-provider.ts
+++ b/src/functions/sendCandidateResults/application/service/fault-provider.ts
@@ -1,25 +1,46 @@
-import {
-  TestData,
-  ManoeuvreOutcome,
-} from '@dvsa/mes-test-schema/categories/common';
+import { TestData, ManoeuvreOutcome } from '@dvsa/mes-test-schema/categories/common';
 import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE';
-import { injectable } from 'inversify';
-import 'reflect-metadata';
+import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
+import { CatCEUniqueTypes } from '@dvsa/mes-test-schema/categories/CE';
+import { CatC1UniqueTypes } from '@dvsa/mes-test-schema/categories/C1';
+import { CatC1EUniqueTypes } from '@dvsa/mes-test-schema/categories/C1E';
 import { Fault } from '../../domain/fault';
 import { Competencies } from '../../domain/competencies';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+import { injectable } from 'inversify';
+import 'reflect-metadata';
 import {
   getDrivingFaultsCatB,
   getSeriousFaultsCatB,
   getDangerousFaultsCatB,
 } from './categories/B/fault-provider-cat-b';
-
 import {
   getDangerousFaultsCatBE,
   getDrivingFaultsCatBE,
   getSeriousFaultsCatBE,
 } from './categories/BE/fault-provider-cat-be';
-import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+import {
+  getDangerousFaultsCatC,
+  getDrivingFaultsCatC,
+  getSeriousFaultsCatC,
+} from './categories/C/fault-provider-cat-c';
+import {
+  getDangerousFaultsCatCE,
+  getDrivingFaultsCatCE,
+  getSeriousFaultsCatCE,
+} from './categories/CE/fault-provider-cat-ce';
+import {
+  getDangerousFaultsCatC1,
+  getDrivingFaultsCatC1,
+  getSeriousFaultsCatC1,
+} from './categories/C1/fault-provider-cat-c1';
+import {
+  getDangerousFaultsCatC1E,
+  getDrivingFaultsCatC1E,
+  getSeriousFaultsCatC1E,
+} from './categories/C1E/fault-provider-cat-c1e';
+
 export interface IFaultProvider {
   getDrivingFaults(testData: TestData | undefined, category: string): Fault[];
 
@@ -32,54 +53,60 @@ export interface IFaultProvider {
 export class FaultProvider implements IFaultProvider {
 
   public getDrivingFaults(testData: TestData | undefined, category: string): Fault[] {
-    let faults: Fault[] = [];
-
     switch (category) {
       case TestCategory.B:
-        faults = getDrivingFaultsCatB(testData as CatBUniqueTypes.TestData);
-        break;
+        return getDrivingFaultsCatB(testData as CatBUniqueTypes.TestData);
       case TestCategory.BE:
-        faults = getDrivingFaultsCatBE(testData as CatBEUniqueTypes.TestData);
-        break;
+        return getDrivingFaultsCatBE(testData as CatBEUniqueTypes.TestData);
+      case TestCategory.C:
+        return getDrivingFaultsCatC(testData as CatCUniqueTypes.TestData);
+      case TestCategory.C1:
+        return getDrivingFaultsCatC1(testData as CatC1UniqueTypes.TestData);
+      case TestCategory.CE:
+        return getDrivingFaultsCatCE(testData as CatCEUniqueTypes.TestData);
+      case TestCategory.C1E:
+        return getDrivingFaultsCatC1E(testData as CatC1EUniqueTypes.TestData);
       default:
-        faults = getDrivingFaultsCatB(testData as CatBUniqueTypes.TestData);
-        break;
+        return getDrivingFaultsCatB(testData as CatBUniqueTypes.TestData);
     }
-    return faults;
   }
 
   public getSeriousFaults(testData: TestData | undefined, category: string): Fault[] {
-    let faults: Fault[] = [];
-
     switch (category) {
       case TestCategory.B:
-        faults = getSeriousFaultsCatB(testData as CatBUniqueTypes.TestData);
-        break;
+        return getSeriousFaultsCatB(testData as CatBUniqueTypes.TestData);
       case TestCategory.BE:
-        faults = getSeriousFaultsCatBE(testData as CatBEUniqueTypes.TestData);
-        break;
+        return getSeriousFaultsCatBE(testData as CatBEUniqueTypes.TestData);
+      case TestCategory.C:
+        return getSeriousFaultsCatC(testData as CatCUniqueTypes.TestData);
+      case TestCategory.C1:
+        return getSeriousFaultsCatC1(testData as CatC1UniqueTypes.TestData);
+      case TestCategory.CE:
+        return getSeriousFaultsCatCE(testData as CatCEUniqueTypes.TestData);
+      case TestCategory.C1E:
+        return getSeriousFaultsCatC1E(testData as CatC1EUniqueTypes.TestData);
       default:
-        faults = getSeriousFaultsCatB(testData as CatBUniqueTypes.TestData);
-        break;
+        return getSeriousFaultsCatB(testData as CatBUniqueTypes.TestData);
     }
-    return faults;
   }
 
   public getDangerousFaults(testData: TestData | undefined, category: string): Fault [] {
-    let faults: Fault[] = [];
-
     switch (category) {
       case TestCategory.B:
-        faults = getDangerousFaultsCatB(testData as CatBUniqueTypes.TestData);
-        break;
+        return getDangerousFaultsCatB(testData as CatBUniqueTypes.TestData);
       case TestCategory.BE:
-        faults = getDangerousFaultsCatBE(testData as CatBEUniqueTypes.TestData);
-        break;
+        return getDangerousFaultsCatBE(testData as CatBEUniqueTypes.TestData);
+      case TestCategory.C:
+        return getDangerousFaultsCatC(testData as CatCUniqueTypes.TestData);
+      case TestCategory.C1:
+        return getDangerousFaultsCatC1(testData as CatC1UniqueTypes.TestData);
+      case TestCategory.CE:
+        return getDangerousFaultsCatCE(testData as CatCEUniqueTypes.TestData);
+      case TestCategory.C1E:
+        return getDangerousFaultsCatC1E(testData as CatC1EUniqueTypes.TestData);
       default:
-        faults = getDangerousFaultsCatB(testData as CatBUniqueTypes.TestData);
-        break;
+        return getDangerousFaultsCatB(testData as CatBUniqueTypes.TestData);
     }
-    return faults;
   }
 }
 

--- a/src/functions/sendCandidateResults/application/service/template-id-provider.ts
+++ b/src/functions/sendCandidateResults/application/service/template-id-provider.ts
@@ -7,6 +7,7 @@ import {
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 
 import { IConfigAdapter } from '../../framework/adapter/config/config-adapter.interface';
+import { Correspondence, CorrespondenceMethod, Language, TestType } from '../../domain/template-id.model';
 import { TYPES } from '../../framework/di/types';
 import { inject, injectable } from 'inversify';
 import { get } from 'lodash';
@@ -14,16 +15,6 @@ import { get } from 'lodash';
 export interface ITemplateIdProvider {
   getTemplateId(
     communicationPreferences: CommunicationPreferences, activityCode: ActivityCode, category: CategoryCode): string;
-}
-
-type CorrespondenceMethod = 'Email' | 'Letter';
-enum Language {
-  ENGLISH = 'english',
-  WELSH = 'welsh',
-  CYMRAEG = 'Cymraeg',
-}
-enum TestType {
-  VOCATIONAL = 'Vocational',
 }
 
 @injectable()
@@ -69,8 +60,11 @@ export function isVocationalCategory(category: CategoryCode): boolean {
 export function getTemplateString(
   conductedLanguage: ConductedLanguage, communicationMethod: CommunicationMethod, activityCode: ActivityCode): string {
 
-  const languageOfTemplate: Language = (conductedLanguage === Language.CYMRAEG) ? Language.WELSH : Language.ENGLISH;
-  const correspondenceMethod: CorrespondenceMethod = (communicationMethod === 'Post') ? 'Letter' : 'Email';
+  const languageOfTemplate: Language =
+    (conductedLanguage === Language.CYMRAEG) ? Language.WELSH : Language.ENGLISH;
+
+  const correspondenceMethod: CorrespondenceMethod =
+    (communicationMethod === Correspondence.POST) ? Correspondence.LETTER : Correspondence.EMAIL;
 
   if (isPass(activityCode)) {
     return `${languageOfTemplate}${correspondenceMethod}PassTemplateId`;

--- a/src/functions/sendCandidateResults/application/service/template-id-provider.ts
+++ b/src/functions/sendCandidateResults/application/service/template-id-provider.ts
@@ -67,7 +67,7 @@ export function getTemplateString(
   conductedLanguage: ConductedLanguage, communicationMethod: CommunicationMethod, activityCode: ActivityCode): string {
 
   const languageOfTemplate: TemplateLanguage =
-    (conductedLanguage === Language.CYMRAEG) ? TemplateLanguage.WELSH : TemplateLanguage.ENGLISH;
+    (conductedLanguage === Language.WELSH) ? TemplateLanguage.WELSH : TemplateLanguage.ENGLISH;
 
   const correspondenceMethod: CorrespondenceMethod =
     (communicationMethod === Correspondence.POST) ? Correspondence.LETTER : Correspondence.EMAIL;

--- a/src/functions/sendCandidateResults/application/service/template-id-provider.ts
+++ b/src/functions/sendCandidateResults/application/service/template-id-provider.ts
@@ -7,7 +7,13 @@ import {
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 
 import { IConfigAdapter } from '../../framework/adapter/config/config-adapter.interface';
-import { Correspondence, CorrespondenceMethod, Language, TestType } from '../../domain/template-id.model';
+import {
+  Correspondence,
+  CorrespondenceMethod,
+  Language,
+  TemplateLanguage,
+  TestType,
+} from '../../domain/template-id.model';
 import { TYPES } from '../../framework/di/types';
 import { inject, injectable } from 'inversify';
 import { get } from 'lodash';
@@ -60,8 +66,8 @@ export function isVocationalCategory(category: CategoryCode): boolean {
 export function getTemplateString(
   conductedLanguage: ConductedLanguage, communicationMethod: CommunicationMethod, activityCode: ActivityCode): string {
 
-  const languageOfTemplate: Language =
-    (conductedLanguage === Language.CYMRAEG) ? Language.WELSH : Language.ENGLISH;
+  const languageOfTemplate: TemplateLanguage =
+    (conductedLanguage === Language.CYMRAEG) ? TemplateLanguage.WELSH : TemplateLanguage.ENGLISH;
 
   const correspondenceMethod: CorrespondenceMethod =
     (communicationMethod === Correspondence.POST) ? Correspondence.LETTER : Correspondence.EMAIL;

--- a/src/functions/sendCandidateResults/application/service/template-id-provider.ts
+++ b/src/functions/sendCandidateResults/application/service/template-id-provider.ts
@@ -1,57 +1,51 @@
-import { ActivityCode, ConductedLanguage } from '@dvsa/mes-test-schema/categories/common';
+import {
+  ActivityCode,
+  CategoryCode, CommunicationMethod,
+  CommunicationPreferences,
+  ConductedLanguage,
+} from '@dvsa/mes-test-schema/categories/common';
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+
 import { IConfigAdapter } from '../../framework/adapter/config/config-adapter.interface';
 import { TYPES } from '../../framework/di/types';
 import { inject, injectable } from 'inversify';
+import { get } from 'lodash';
 
 export interface ITemplateIdProvider {
-  getEmailTemplateId(language: ConductedLanguage, activityCode: ActivityCode): string;
+  getTemplateId(
+    communicationPreferences: CommunicationPreferences, activityCode: ActivityCode, category: CategoryCode): string;
+}
 
-  getLetterTemplateId(language: ConductedLanguage, activityCode: ActivityCode): string;
+type CorrespondenceMethod = 'Email' | 'Letter';
+enum Language {
+  ENGLISH = 'english',
+  WELSH = 'welsh',
+  CYMRAEG = 'Cymraeg',
+}
+enum TestType {
+  VOCATIONAL = 'Vocational',
 }
 
 @injectable()
 export class TemplateIdProvider implements ITemplateIdProvider {
   static TEMPLATE_ID_NOT_SET = 'Template Id not set';
-  constructor(@inject(TYPES.IConfigAdapter) private configAdapter: IConfigAdapter) {
+
+  constructor(@inject(TYPES.IConfigAdapter) public configAdapter: IConfigAdapter) {
   }
 
-  getEmailTemplateId(language: ConductedLanguage, activityCode: ActivityCode): string {
-    if (language === 'Cymraeg') {
-      if (isPass(activityCode)) {
-        return this.configAdapter.welshEmailPassTemplateId;
-      }
-      if (isFail(activityCode)) {
-        return this.configAdapter.welshEmailFailTemplateId;
-      }
+  getTemplateId(
+    communicationPreferences: CommunicationPreferences, activityCode: ActivityCode, category: CategoryCode): string {
+
+    const { conductedLanguage, communicationMethod } = communicationPreferences;
+    const baseTemplate: string = getTemplateString(conductedLanguage, communicationMethod, activityCode);
+
+    if (baseTemplate === TemplateIdProvider.TEMPLATE_ID_NOT_SET) {
       return TemplateIdProvider.TEMPLATE_ID_NOT_SET;
     }
-    if (isPass(activityCode)) {
-      return this.configAdapter.englishEmailPassTemplateId;
+    if (isVocationalCategory(category)) {
+      return get(this.configAdapter, `${baseTemplate}${TestType.VOCATIONAL}`);
     }
-    if (isFail(activityCode)) {
-      return this.configAdapter.englishEmailFailTemplateId;
-    }
-    return TemplateIdProvider.TEMPLATE_ID_NOT_SET;
-  }
-
-  getLetterTemplateId(language: ConductedLanguage, activityCode: ActivityCode): string {
-    if (language === 'Cymraeg') {
-      if (isPass(activityCode)) {
-        return this.configAdapter.welshLetterPassTemplateId;
-      }
-      if (isFail(activityCode)) {
-        return this.configAdapter.welshLetterFailTemplateId;
-      }
-      return TemplateIdProvider.TEMPLATE_ID_NOT_SET;
-    }
-
-    if (isPass(activityCode)) {
-      return this.configAdapter.englishLetterPassTemplateId;
-    }
-    if (isFail(activityCode)) {
-      return this.configAdapter.englishLetterFailTemplateId;
-    }
-    return TemplateIdProvider.TEMPLATE_ID_NOT_SET;
+    return get(this.configAdapter, baseTemplate);
   }
 }
 
@@ -61,4 +55,28 @@ export function isPass(activityCode: ActivityCode): boolean {
 
 export function isFail(activityCode: ActivityCode): boolean {
   return activityCode === '2' || activityCode === '3' || activityCode === '4' || activityCode === '5';
+}
+
+export function isVocationalCategory(category: CategoryCode): boolean {
+  return [
+    TestCategory.C,
+    TestCategory.CE,
+    TestCategory.C1,
+    TestCategory.C1E,
+  ].includes(category as TestCategory);
+}
+
+export function getTemplateString(
+  conductedLanguage: ConductedLanguage, communicationMethod: CommunicationMethod, activityCode: ActivityCode): string {
+
+  const languageOfTemplate: Language = (conductedLanguage === Language.CYMRAEG) ? Language.WELSH : Language.ENGLISH;
+  const correspondenceMethod: CorrespondenceMethod = (communicationMethod === 'Post') ? 'Letter' : 'Email';
+
+  if (isPass(activityCode)) {
+    return `${languageOfTemplate}${correspondenceMethod}PassTemplateId`;
+  }
+  if (isFail(activityCode)) {
+    return `${languageOfTemplate}${correspondenceMethod}FailTemplateId`;
+  }
+  return TemplateIdProvider.TEMPLATE_ID_NOT_SET;
 }

--- a/src/functions/sendCandidateResults/domain/competencies.ts
+++ b/src/functions/sendCandidateResults/domain/competencies.ts
@@ -1,4 +1,3 @@
-
 export enum Competencies {
     controlsAccelerator = 'controlsAccelerator',
     controlsClutch = 'controlsClutch',
@@ -53,7 +52,7 @@ export enum Competencies {
     uncoupleRecouple = 'uncoupleRecouple',
     reverseLeftControl = 'reverseLeftControl',
     reverseLeftObservation = 'reverseLeftObservation',
-  }
+}
 
 export enum englishCompetencyLabels {
     controlsAccelerator = 'Controls - Accelerator',
@@ -110,7 +109,7 @@ export enum englishCompetencyLabels {
     reverseLeftControl = 'Reverse - Control',
     reverseLeftObservation = 'Reverse - Observation',
     uncoupleRecouple = 'Uncouple / Recouple',
-  }
+}
 
 export enum welshCompetencyLabels {
   controlsAccelerator = 'Rheolaeth - sbardun',
@@ -167,4 +166,4 @@ export enum welshCompetencyLabels {
   uncoupleRecouple = 'Dadfachu / Ailfachu',
   reverseLeftObservation = 'Gwrthdroi - gwyliadwriaeth',
   reverseLeftControl = 'Gwrthdroi - dan reolaeth',
-  }
+}

--- a/src/functions/sendCandidateResults/domain/fault.ts
+++ b/src/functions/sendCandidateResults/domain/fault.ts
@@ -4,3 +4,5 @@ export interface Fault {
   name: Competencies;
   count: number;
 }
+
+export const vehicleCheckDrivingFaultLimit: number = 5;

--- a/src/functions/sendCandidateResults/domain/template-id.model.ts
+++ b/src/functions/sendCandidateResults/domain/template-id.model.ts
@@ -1,0 +1,17 @@
+export type CorrespondenceMethod = 'Email' | 'Letter';
+
+export enum Language {
+  ENGLISH = 'english',
+  WELSH = 'welsh',
+  CYMRAEG = 'Cymraeg',
+}
+
+export enum TestType {
+  VOCATIONAL = 'Vocational',
+}
+
+export enum Correspondence {
+  POST = 'Post',
+  LETTER = 'Letter',
+  EMAIL = 'Email',
+}

--- a/src/functions/sendCandidateResults/domain/template-id.model.ts
+++ b/src/functions/sendCandidateResults/domain/template-id.model.ts
@@ -1,7 +1,7 @@
 export type CorrespondenceMethod = 'Email' | 'Letter';
 
 export enum Language {
-  CYMRAEG = 'Cymraeg',
+  WELSH = 'Cymraeg',
 }
 
 export enum TemplateLanguage {

--- a/src/functions/sendCandidateResults/domain/template-id.model.ts
+++ b/src/functions/sendCandidateResults/domain/template-id.model.ts
@@ -1,9 +1,12 @@
 export type CorrespondenceMethod = 'Email' | 'Letter';
 
 export enum Language {
+  CYMRAEG = 'Cymraeg',
+}
+
+export enum TemplateLanguage {
   ENGLISH = 'english',
   WELSH = 'welsh',
-  CYMRAEG = 'Cymraeg',
 }
 
 export enum TestType {

--- a/src/functions/sendCandidateResults/framework/adapter/config/__mocks__/config-adapter.mock.ts
+++ b/src/functions/sendCandidateResults/framework/adapter/config/__mocks__/config-adapter.mock.ts
@@ -14,15 +14,25 @@ export class ConfigAdapterMock implements IConfigAdapter {
   notifyRequestsPerBatch: number = 25;
   notifyTimeout: number = 1000;
 
-  englishEmailPassTemplateId: string = 'email-pass-template-id';
-  englishEmailFailTemplateId: string = 'email-fail-template-id';
+  englishEmailPassTemplateId: string = 'email-english-pass-template-id';
+  englishEmailFailTemplateId: string = 'email-english-fail-template-id';
   welshEmailPassTemplateId: string = 'email-welsh-pass-template-id';
   welshEmailFailTemplateId: string = 'email-welsh-fail-template-id';
 
-  englishLetterPassTemplateId: string = 'post-pass-template-id';
-  englishLetterFailTemplateId: string = 'post-fail-template-id';
+  englishLetterPassTemplateId: string = 'post-english-pass-template-id';
+  englishLetterFailTemplateId: string = 'post-english-fail-template-id';
   welshLetterPassTemplateId: string = 'post-welsh-pass-template-id';
   welshLetterFailTemplateId: string = 'post-welsh-fail-template-id';
+
+  englishEmailPassTemplateIdVocational: string = 'email-english-pass-template-id-vocational';
+  englishEmailFailTemplateIdVocational: string = 'email-english-fail-template-id-vocational';
+  welshEmailPassTemplateIdVocational: string = 'email-welsh-pass-template-id-vocational';
+  welshEmailFailTemplateIdVocational: string = 'email-welsh-fail-template-id-vocational';
+
+  englishLetterPassTemplateIdVocational: string = 'post-english-pass-template-id-vocational';
+  englishLetterFailTemplateIdVocational: string = 'post-english-fail-template-id-vocational';
+  welshLetterPassTemplateIdVocational: string = 'post-welsh-pass-template-id-vocational';
+  welshLetterFailTemplateIdVocational: string = 'post-welsh-fail-template-id-vocational';
 
   async getApiKey(): Promise<string> {
     return Promise.resolve(this.apiKey);

--- a/src/functions/sendCandidateResults/framework/adapter/config/config-adapter.interface.ts
+++ b/src/functions/sendCandidateResults/framework/adapter/config/config-adapter.interface.ts
@@ -16,6 +16,16 @@ export interface IConfigAdapter {
   englishLetterFailTemplateId: string;
   welshLetterPassTemplateId: string;
   welshLetterFailTemplateId: string;
+  // Email Template Id's Vocational
+  englishEmailPassTemplateIdVocational: string;
+  englishEmailFailTemplateIdVocational: string;
+  welshEmailPassTemplateIdVocational: string;
+  welshEmailFailTemplateIdVocational: string;
+  // Letter Template Id's Vocational
+  englishLetterPassTemplateIdVocational: string;
+  englishLetterFailTemplateIdVocational: string;
+  welshLetterPassTemplateIdVocational: string;
+  welshLetterFailTemplateIdVocational: string;
 
   getApiKey(): Promise<string>;
 }

--- a/src/functions/sendCandidateResults/framework/adapter/config/config-adapter.ts
+++ b/src/functions/sendCandidateResults/framework/adapter/config/config-adapter.ts
@@ -25,6 +25,16 @@ export class ConfigAdapter implements IConfigAdapter {
   englishLetterFailTemplateId: string;
   welshLetterPassTemplateId: string;
   welshLetterFailTemplateId: string;
+  // Email Template Id's Vocational
+  englishEmailPassTemplateIdVocational: string;
+  englishEmailFailTemplateIdVocational: string;
+  welshEmailPassTemplateIdVocational: string;
+  welshEmailFailTemplateIdVocational: string;
+  // Letter Template Id's Vocational
+  englishLetterPassTemplateIdVocational: string;
+  englishLetterFailTemplateIdVocational: string;
+  welshLetterPassTemplateIdVocational: string;
+  welshLetterFailTemplateIdVocational: string;
 
   constructor() {
     this.apiKey = '';
@@ -45,6 +55,24 @@ export class ConfigAdapter implements IConfigAdapter {
     this.englishLetterFailTemplateId = this.getFromEnvThrowIfNotPresent('NOTIFY_POST_FAIL_TEMPLATE_ID');
     this.welshLetterPassTemplateId = this.getFromEnvThrowIfNotPresent('NOTIFY_POST_WELSH_PASS_TEMPLATE_ID');
     this.welshLetterFailTemplateId = this.getFromEnvThrowIfNotPresent('NOTIFY_POST_WELSH_FAIL_TEMPLATE_ID');
+
+    this.englishEmailPassTemplateIdVocational =
+      this.getFromEnvThrowIfNotPresent('NOTIFY_EMAIL_PASS_TEMPLATE_ID_VOCATIONAL');
+    this.englishEmailFailTemplateIdVocational =
+      this.getFromEnvThrowIfNotPresent('NOTIFY_EMAIL_FAIL_TEMPLATE_ID_VOCATIONAL');
+    this.welshEmailPassTemplateIdVocational =
+      this.getFromEnvThrowIfNotPresent('NOTIFY_EMAIL_WELSH_PASS_TEMPLATE_ID_VOCATIONAL');
+    this.welshEmailFailTemplateIdVocational =
+      this.getFromEnvThrowIfNotPresent('NOTIFY_EMAIL_WELSH_FAIL_TEMPLATE_ID_VOCATIONAL');
+
+    this.englishLetterPassTemplateIdVocational =
+      this.getFromEnvThrowIfNotPresent('NOTIFY_POST_PASS_TEMPLATE_ID_VOCATIONAL');
+    this.englishLetterFailTemplateIdVocational =
+      this.getFromEnvThrowIfNotPresent('NOTIFY_POST_FAIL_TEMPLATE_ID_VOCATIONAL');
+    this.welshLetterPassTemplateIdVocational =
+      this.getFromEnvThrowIfNotPresent('NOTIFY_POST_WELSH_PASS_TEMPLATE_ID_VOCATIONAL');
+    this.welshLetterFailTemplateIdVocational =
+      this.getFromEnvThrowIfNotPresent('NOTIFY_POST_WELSH_FAIL_TEMPLATE_ID_VOCATIONAL');
   }
 
   public async getApiKey(): Promise<string> {

--- a/src/functions/sendCandidateResults/framework/request-scheduler.ts
+++ b/src/functions/sendCandidateResults/framework/request-scheduler.ts
@@ -115,6 +115,8 @@ export class RequestScheduler implements IRequestScheduler {
   }
 
   private sendNotifyRequest(testResult: TestResultSchemasUnion): Promise<any> {
+    const { category } = testResult;
+
     if (!testResult.communicationPreferences) {
       return Promise.reject();
     }
@@ -123,13 +125,10 @@ export class RequestScheduler implements IRequestScheduler {
       return Promise.resolve();
     }
 
-    if (testResult.communicationPreferences.communicationMethod === 'Email') {
-      const templateId: string =
-        this.templateIdProvider.getEmailTemplateId(
-          testResult.communicationPreferences.conductedLanguage,
-          testResult.activityCode,
-        );
+    const templateId: string =
+      this.templateIdProvider.getTemplateId(testResult.communicationPreferences, testResult.activityCode, category);
 
+    if (testResult.communicationPreferences.communicationMethod === 'Email') {
       return sendEmail(
         testResult.communicationPreferences.updatedEmail,
         templateId,
@@ -139,11 +138,6 @@ export class RequestScheduler implements IRequestScheduler {
         this.notifyClient,
       );
     }
-
-    const templateId: string = this.templateIdProvider.getLetterTemplateId(
-      testResult.communicationPreferences.conductedLanguage,
-      testResult.activityCode,
-    );
 
     return sendLetter(
       templateId,


### PR DESCRIPTION
Added fault providers for Cat C and all sub categories, added logic to use different templates when Category is one of: C, C1, CE, C1+E. Updated logic to simplify which template is required, incase of more templates being necessary in future for other categories.