### PR TITLE
MES-4100 / Notify Cat D and sub categories

### DIFF
--- a/src/functions/sendCandidateResults/application/service/__tests__/template-id-provider.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/__tests__/template-id-provider.spec.ts
@@ -7,6 +7,7 @@ import {
   ConductedLanguage,
 } from '@dvsa/mes-test-schema/categories/common';
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
+import { sample } from 'lodash';
 
 const communicationPreferences: CommunicationPreferences = {
   updatedEmail: 'email@somewhere.com',
@@ -164,6 +165,10 @@ describe('get-template-id-provider', () => {
       expect(isVocationalCategory(TestCategory.C1)).toBe(true);
       expect(isVocationalCategory(TestCategory.CE)).toBe(true);
       expect(isVocationalCategory(TestCategory.C1E)).toBe(true);
+      expect(isVocationalCategory(TestCategory.D)).toBe(true);
+      expect(isVocationalCategory(TestCategory.D1)).toBe(true);
+      expect(isVocationalCategory(TestCategory.DE)).toBe(true);
+      expect(isVocationalCategory(TestCategory.D1E)).toBe(true);
     });
 
     it('should return false when category is not in the vocational category array', () => {

--- a/src/functions/sendCandidateResults/application/service/__tests__/template-id-provider.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/__tests__/template-id-provider.spec.ts
@@ -7,7 +7,6 @@ import {
   ConductedLanguage,
 } from '@dvsa/mes-test-schema/categories/common';
 import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
-import { sample } from 'lodash';
 
 const communicationPreferences: CommunicationPreferences = {
   updatedEmail: 'email@somewhere.com',

--- a/src/functions/sendCandidateResults/application/service/categories/D/__tests__/fault-provider-cat-d.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/D/__tests__/fault-provider-cat-d.spec.ts
@@ -1,0 +1,236 @@
+import { CatDUniqueTypes } from '@dvsa/mes-test-schema/categories/D';
+import { CompetencyOutcome } from '../../../../../domain/competency-outcome';
+import { Fault } from '../../../../../domain/fault';
+import {
+  getDangerousFaultsCatD,
+  getDrivingFaultsCatD,
+  getNonStandardFaultsCatD,
+  getSeriousFaultsCatD,
+  getVehicleChecksFaultCatD,
+} from '../fault-provider-cat-d';
+import { Competencies } from '../../../../../domain/competencies';
+
+describe('fault-provider-cat-d', () => {
+  describe('getVehicleChecksFaultCatD', () => {
+    it('should find a dangerous fault if one exists', () => {
+      const data: CatDUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.D,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatD(data, CompetencyOutcome.D);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should not find a dangerous fault if none exists', () => {
+      const data: CatDUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatD(data, CompetencyOutcome.D);
+      expect(result.length).toBe(0);
+    });
+
+    it('should find a serious fault if one exists', () => {
+      const data: CatDUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.S,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatD(data, CompetencyOutcome.S);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should not find a serious fault if none exist', () => {
+      const data: CatDUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatD(data, CompetencyOutcome.S);
+      expect(result.length).toBe(0);
+    });
+
+    it('should find a driving fault if one exists', () => {
+      const data: CatDUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatD(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should return a serious fault when 5 vehicle check driving faults', () => {
+      const vehicleChecks: CatDUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        },
+          {
+            code: 'S02',
+            description: 'S02',
+            outcome: CompetencyOutcome.DF,
+          },
+          {
+            code: 'S03',
+            description: 'S03',
+            outcome: CompetencyOutcome.DF,
+          }],
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        },
+          {
+            code: 'T02',
+            description: 'T02',
+            outcome: CompetencyOutcome.DF,
+          }],
+      };
+      const data: CatDUniqueTypes.TestData = {
+        vehicleChecks,
+        seriousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.S,
+          },
+        },
+      };
+      const result: Fault[] = getSeriousFaultsCatD(data);
+      expect(result.length).toBe(3);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+
+    it('should only return one driving fault with a count of two if two exist', () => {
+      const data: CatDUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+
+      const result: Fault[] = getVehicleChecksFaultCatD(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 2 });
+    });
+
+    it('should return one driving fault with a count of 1', () => {
+      const data: CatDUniqueTypes.VehicleChecks = {
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatD(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+  });
+
+  describe('getDangerousFaultsCatD', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatDUniqueTypes.TestData = {
+        dangerousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.D,
+          },
+        },
+      };
+      const result: Fault [] = getDangerousFaultsCatD(data);
+      expect(result.length).toBe(2);
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+  });
+
+  describe('getSeriousFaultsCatD', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatDUniqueTypes.TestData = {
+        seriousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.S,
+          },
+        },
+      };
+
+      const result: Fault [] = getSeriousFaultsCatD(data);
+      expect(result.length).toBe(2);
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+  });
+
+  describe('getDrivingFaultsCatD', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatDUniqueTypes.TestData = {
+        drivingFaults: {
+          ancillaryControls: 1,
+          awarenessPlanning: 0,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.DF,
+          },
+        },
+      };
+      const result: Fault [] = getDrivingFaultsCatD(data);
+
+      expect(result.length).toBe(2);
+      expect(result).toEqual([
+        { name: Competencies.ancillaryControls, count: 1 },
+        { name: Competencies.reverseLeftControl, count: 1 },
+      ]);
+    });
+  });
+
+  describe('getNonStandardFaultsCatD', () => {
+    it('should return an empty array when no faults recorded', () => {
+      const data: CatDUniqueTypes.TestData = {
+        vehicleChecks: {},
+        manoeuvres: {},
+      };
+      const result: Fault[] = getNonStandardFaultsCatD(data, CompetencyOutcome.DF);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/functions/sendCandidateResults/application/service/categories/D/fault-provider-cat-d.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/D/fault-provider-cat-d.ts
@@ -1,0 +1,124 @@
+import { CatDUniqueTypes } from '@dvsa/mes-test-schema/categories/D';
+import { Fault, vehicleCheckDrivingFaultLimit } from '../../../../domain/fault';
+import { CompetencyOutcome } from '../../../../domain/competency-outcome';
+import {
+  convertBooleanFaultObjectToArray,
+  convertNumericFaultObjectToArray,
+  getCompletedManoeuvres,
+} from '../../fault-provider';
+import { Competencies } from '../../../../domain/competencies';
+import { QuestionOutcome, QuestionResult } from '@dvsa/mes-test-schema/categories/common';
+
+export const getDrivingFaultsCatD = (testData: CatDUniqueTypes.TestData | undefined): Fault [] => {
+  const drivingFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.drivingFaults) {
+    convertNumericFaultObjectToArray(testData.drivingFaults)
+      .forEach(fault => drivingFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatD(testData, CompetencyOutcome.DF)
+    .forEach(fault => drivingFaults.push(fault));
+
+  return drivingFaults;
+};
+
+export const getSeriousFaultsCatD = (testData: CatDUniqueTypes.TestData | undefined): Fault [] => {
+  const seriousFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.seriousFaults) {
+    convertBooleanFaultObjectToArray(testData.seriousFaults)
+      .forEach(fault => seriousFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatD(testData, CompetencyOutcome.S)
+    .forEach(fault => seriousFaults.push(fault));
+
+  if (getVehicleCheckFaultCount(
+    testData.vehicleChecks as CatDUniqueTypes.VehicleChecks, CompetencyOutcome.DF) === vehicleCheckDrivingFaultLimit) {
+    seriousFaults.push({ name: Competencies.vehicleChecks, count: 1 });
+  }
+
+  return seriousFaults;
+};
+
+const getVehicleCheckFaultCount = (
+  vehicleChecks: CatDUniqueTypes.VehicleChecks,
+  faultType: QuestionOutcome): number => {
+  let questionCount: number = 0;
+
+  if (!vehicleChecks) {
+    return questionCount;
+  }
+
+  if (vehicleChecks.showMeQuestions) {
+    questionCount = questionCount +
+      vehicleChecks.showMeQuestions.filter((showMe: QuestionResult) => showMe.outcome === faultType).length;
+  }
+  if (vehicleChecks.tellMeQuestions) {
+    questionCount = questionCount +
+      vehicleChecks.tellMeQuestions.filter((tellMe: QuestionResult) => tellMe.outcome === faultType).length;
+  }
+  return questionCount;
+};
+
+export const getDangerousFaultsCatD = (testData: CatDUniqueTypes.TestData | undefined): Fault [] => {
+  const dangerousFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.dangerousFaults) {
+    convertBooleanFaultObjectToArray(testData.dangerousFaults)
+      .forEach(fault => dangerousFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatD(testData, CompetencyOutcome.D)
+    .forEach(fault => dangerousFaults.push(fault));
+
+  return dangerousFaults;
+};
+
+export const getNonStandardFaultsCatD = (
+  testData: CatDUniqueTypes.TestData,
+  faultType: CompetencyOutcome): Fault[] => {
+
+  const faults: Fault[] = [];
+
+// Manoeuvres
+  if (testData.manoeuvres) {
+    getCompletedManoeuvres(testData.manoeuvres, faultType)
+      .forEach(fault => faults.push(fault));
+  }
+
+// Vehicle Checks
+  if (testData.vehicleChecks) {
+    getVehicleChecksFaultCatD(testData.vehicleChecks, faultType)
+      .forEach(fault => faults.push(fault));
+  }
+
+  return faults;
+};
+
+export const getVehicleChecksFaultCatD = (
+  vehicleChecks: CatDUniqueTypes.VehicleChecks,
+  faultType: QuestionOutcome): Fault[] => {
+  const faultArray: Fault[] = [];
+  const faultCount = getVehicleCheckFaultCount(vehicleChecks, faultType);
+
+  if (faultCount > 0) {
+    faultArray.push(
+      { name: Competencies.vehicleChecks, count: faultCount === vehicleCheckDrivingFaultLimit ? 4 : faultCount },
+    );
+  }
+  return faultArray;
+};

--- a/src/functions/sendCandidateResults/application/service/categories/D/fault-provider-cat-d.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/D/fault-provider-cat-d.ts
@@ -1,5 +1,5 @@
 import { CatDUniqueTypes } from '@dvsa/mes-test-schema/categories/D';
-import { Fault, vehicleCheckDrivingFaultLimit } from '../../../../domain/fault';
+import { Fault, FaultLimit } from '../../../../domain/fault';
 import { CompetencyOutcome } from '../../../../domain/competency-outcome';
 import {
   convertBooleanFaultObjectToArray,
@@ -43,7 +43,7 @@ export const getSeriousFaultsCatD = (testData: CatDUniqueTypes.TestData | undefi
     .forEach(fault => seriousFaults.push(fault));
 
   if (getVehicleCheckFaultCount(
-    testData.vehicleChecks as CatDUniqueTypes.VehicleChecks, CompetencyOutcome.DF) === vehicleCheckDrivingFaultLimit) {
+    testData.vehicleChecks as CatDUniqueTypes.VehicleChecks, CompetencyOutcome.DF) === FaultLimit.NON_TRAILER) {
     seriousFaults.push({ name: Competencies.vehicleChecks, count: 1 });
   }
 
@@ -117,7 +117,7 @@ export const getVehicleChecksFaultCatD = (
 
   if (faultCount > 0) {
     faultArray.push(
-      { name: Competencies.vehicleChecks, count: faultCount === vehicleCheckDrivingFaultLimit ? 4 : faultCount },
+      { name: Competencies.vehicleChecks, count: faultCount === FaultLimit.NON_TRAILER ? 4 : faultCount },
     );
   }
   return faultArray;

--- a/src/functions/sendCandidateResults/application/service/categories/D1/__tests__/fault-provider-cat-d1.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/D1/__tests__/fault-provider-cat-d1.spec.ts
@@ -1,0 +1,236 @@
+import { CatD1UniqueTypes } from '@dvsa/mes-test-schema/categories/D1';
+import { CompetencyOutcome } from '../../../../../domain/competency-outcome';
+import { Fault } from '../../../../../domain/fault';
+import {
+  getDangerousFaultsCatD1,
+  getDrivingFaultsCatD1,
+  getNonStandardFaultsCatD1,
+  getSeriousFaultsCatD1,
+  getVehicleChecksFaultCatD1,
+} from '../fault-provider-cat-d1';
+import { Competencies } from '../../../../../domain/competencies';
+
+describe('fault-provider-cat-d1', () => {
+  describe('getVehicleChecksFaultCatD1', () => {
+    it('should find a dangerous fault if one exists', () => {
+      const data: CatD1UniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.D,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatD1(data, CompetencyOutcome.D);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should not find a dangerous fault if none exists', () => {
+      const data: CatD1UniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatD1(data, CompetencyOutcome.D);
+      expect(result.length).toBe(0);
+    });
+
+    it('should find a serious fault if one exists', () => {
+      const data: CatD1UniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.S,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatD1(data, CompetencyOutcome.S);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should not find a serious fault if none exist', () => {
+      const data: CatD1UniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatD1(data, CompetencyOutcome.S);
+      expect(result.length).toBe(0);
+    });
+
+    it('should find a driving fault if one exists', () => {
+      const data: CatD1UniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatD1(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should return a serious fault when 5 vehicle check driving faults', () => {
+      const vehicleChecks: CatD1UniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        },
+          {
+            code: 'S02',
+            description: 'S02',
+            outcome: CompetencyOutcome.DF,
+          },
+          {
+            code: 'S03',
+            description: 'S03',
+            outcome: CompetencyOutcome.DF,
+          }],
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        },
+          {
+            code: 'T02',
+            description: 'T02',
+            outcome: CompetencyOutcome.DF,
+          }],
+      };
+      const data: CatD1UniqueTypes.TestData = {
+        vehicleChecks,
+        seriousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.S,
+          },
+        },
+      };
+      const result: Fault[] = getSeriousFaultsCatD1(data);
+      expect(result.length).toBe(3);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+
+    it('should only return one driving fault with a count of two if two exist', () => {
+      const data: CatD1UniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+
+      const result: Fault[] = getVehicleChecksFaultCatD1(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 2 });
+    });
+
+    it('should return one driving fault with a count of 1', () => {
+      const data: CatD1UniqueTypes.VehicleChecks = {
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatD1(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+  });
+
+  describe('getDangerousFaultsCatD1', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatD1UniqueTypes.TestData = {
+        dangerousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.D,
+          },
+        },
+      };
+      const result: Fault [] = getDangerousFaultsCatD1(data);
+      expect(result.length).toBe(2);
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+  });
+
+  describe('getSeriousFaultsCatD1', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatD1UniqueTypes.TestData = {
+        seriousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.S,
+          },
+        },
+      };
+
+      const result: Fault [] = getSeriousFaultsCatD1(data);
+      expect(result.length).toBe(2);
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+  });
+
+  describe('getDrivingFaultsCatD1', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatD1UniqueTypes.TestData = {
+        drivingFaults: {
+          ancillaryControls: 1,
+          awarenessPlanning: 0,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.DF,
+          },
+        },
+      };
+      const result: Fault [] = getDrivingFaultsCatD1(data);
+
+      expect(result.length).toBe(2);
+      expect(result).toEqual([
+                               { name: Competencies.ancillaryControls, count: 1 },
+                               { name: Competencies.reverseLeftControl, count: 1 },
+      ]);
+    });
+  });
+
+  describe('getNonStandardFaultsCatD1', () => {
+    it('should return an empty array when no faults recorded', () => {
+      const data: CatD1UniqueTypes.TestData = {
+        vehicleChecks: {},
+        manoeuvres: {},
+      };
+      const result: Fault[] = getNonStandardFaultsCatD1(data, CompetencyOutcome.DF);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/functions/sendCandidateResults/application/service/categories/D1/fault-provider-cat-d1.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/D1/fault-provider-cat-d1.ts
@@ -1,0 +1,124 @@
+import { CatD1UniqueTypes } from '@dvsa/mes-test-schema/categories/D1';
+import { Fault, vehicleCheckDrivingFaultLimit } from '../../../../domain/fault';
+import { CompetencyOutcome } from '../../../../domain/competency-outcome';
+import {
+  convertBooleanFaultObjectToArray,
+  convertNumericFaultObjectToArray,
+  getCompletedManoeuvres,
+} from '../../fault-provider';
+import { Competencies } from '../../../../domain/competencies';
+import { QuestionOutcome, QuestionResult } from '@dvsa/mes-test-schema/categories/common';
+
+export const getDrivingFaultsCatD1 = (testData: CatD1UniqueTypes.TestData | undefined): Fault [] => {
+  const drivingFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.drivingFaults) {
+    convertNumericFaultObjectToArray(testData.drivingFaults)
+      .forEach(fault => drivingFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatD1(testData, CompetencyOutcome.DF)
+    .forEach(fault => drivingFaults.push(fault));
+
+  return drivingFaults;
+};
+
+export const getSeriousFaultsCatD1 = (testData: CatD1UniqueTypes.TestData | undefined): Fault [] => {
+  const seriousFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.seriousFaults) {
+    convertBooleanFaultObjectToArray(testData.seriousFaults)
+      .forEach(fault => seriousFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatD1(testData, CompetencyOutcome.S)
+    .forEach(fault => seriousFaults.push(fault));
+
+  if (getVehicleCheckFaultCount(
+    testData.vehicleChecks as CatD1UniqueTypes.VehicleChecks, CompetencyOutcome.DF) === vehicleCheckDrivingFaultLimit) {
+    seriousFaults.push({ name: Competencies.vehicleChecks, count: 1 });
+  }
+
+  return seriousFaults;
+};
+
+const getVehicleCheckFaultCount = (
+  vehicleChecks: CatD1UniqueTypes.VehicleChecks,
+  faultType: QuestionOutcome): number => {
+  let questionCount: number = 0;
+
+  if (!vehicleChecks) {
+    return questionCount;
+  }
+
+  if (vehicleChecks.showMeQuestions) {
+    questionCount = questionCount +
+      vehicleChecks.showMeQuestions.filter((showMe: QuestionResult) => showMe.outcome === faultType).length;
+  }
+  if (vehicleChecks.tellMeQuestions) {
+    questionCount = questionCount +
+      vehicleChecks.tellMeQuestions.filter((tellMe: QuestionResult) => tellMe.outcome === faultType).length;
+  }
+  return questionCount;
+};
+
+export const getDangerousFaultsCatD1 = (testData: CatD1UniqueTypes.TestData | undefined): Fault [] => {
+  const dangerousFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.dangerousFaults) {
+    convertBooleanFaultObjectToArray(testData.dangerousFaults)
+      .forEach(fault => dangerousFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatD1(testData, CompetencyOutcome.D)
+    .forEach(fault => dangerousFaults.push(fault));
+
+  return dangerousFaults;
+};
+
+export const getNonStandardFaultsCatD1 = (
+  testData: CatD1UniqueTypes.TestData,
+  faultType: CompetencyOutcome): Fault[] => {
+
+  const faults: Fault[] = [];
+
+// Manoeuvres
+  if (testData.manoeuvres) {
+    getCompletedManoeuvres(testData.manoeuvres, faultType)
+      .forEach(fault => faults.push(fault));
+  }
+
+// Vehicle Checks
+  if (testData.vehicleChecks) {
+    getVehicleChecksFaultCatD1(testData.vehicleChecks, faultType)
+      .forEach(fault => faults.push(fault));
+  }
+
+  return faults;
+};
+
+export const getVehicleChecksFaultCatD1 = (
+  vehicleChecks: CatD1UniqueTypes.VehicleChecks,
+  faultType: QuestionOutcome): Fault[] => {
+  const faultArray: Fault[] = [];
+  const faultCount = getVehicleCheckFaultCount(vehicleChecks, faultType);
+
+  if (faultCount > 0) {
+    faultArray.push(
+      { name: Competencies.vehicleChecks, count: faultCount === vehicleCheckDrivingFaultLimit ? 4 : faultCount },
+    );
+  }
+  return faultArray;
+};

--- a/src/functions/sendCandidateResults/application/service/categories/D1/fault-provider-cat-d1.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/D1/fault-provider-cat-d1.ts
@@ -1,5 +1,5 @@
 import { CatD1UniqueTypes } from '@dvsa/mes-test-schema/categories/D1';
-import { Fault, vehicleCheckDrivingFaultLimit } from '../../../../domain/fault';
+import { Fault, FaultLimit } from '../../../../domain/fault';
 import { CompetencyOutcome } from '../../../../domain/competency-outcome';
 import {
   convertBooleanFaultObjectToArray,
@@ -43,7 +43,7 @@ export const getSeriousFaultsCatD1 = (testData: CatD1UniqueTypes.TestData | unde
     .forEach(fault => seriousFaults.push(fault));
 
   if (getVehicleCheckFaultCount(
-    testData.vehicleChecks as CatD1UniqueTypes.VehicleChecks, CompetencyOutcome.DF) === vehicleCheckDrivingFaultLimit) {
+    testData.vehicleChecks as CatD1UniqueTypes.VehicleChecks, CompetencyOutcome.DF) === FaultLimit.NON_TRAILER) {
     seriousFaults.push({ name: Competencies.vehicleChecks, count: 1 });
   }
 
@@ -117,7 +117,7 @@ export const getVehicleChecksFaultCatD1 = (
 
   if (faultCount > 0) {
     faultArray.push(
-      { name: Competencies.vehicleChecks, count: faultCount === vehicleCheckDrivingFaultLimit ? 4 : faultCount },
+      { name: Competencies.vehicleChecks, count: faultCount === FaultLimit.NON_TRAILER ? 4 : faultCount },
     );
   }
   return faultArray;

--- a/src/functions/sendCandidateResults/application/service/categories/D1E/__tests__/fault-provider-cat-d1e.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/D1E/__tests__/fault-provider-cat-d1e.spec.ts
@@ -1,0 +1,253 @@
+import { CatD1EUniqueTypes } from '@dvsa/mes-test-schema/categories/D1E';
+import { CompetencyOutcome } from '../../../../../domain/competency-outcome';
+import { Fault } from '../../../../../domain/fault';
+import {
+  getDangerousFaultsCatD1E,
+  getDrivingFaultsCatD1E,
+  getNonStandardFaultsCatD1E,
+  getSeriousFaultsCatD1E,
+  getVehicleChecksFaultCatD1E,
+} from '../fault-provider-cat-d1e';
+import { Competencies } from '../../../../../domain/competencies';
+
+describe('fault-provider-cat-d1e', () => {
+  describe('getVehicleChecksFaultCatD1E', () => {
+    it('should find a dangerous fault if one exists', () => {
+      const data: CatD1EUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.D,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatD1E(data, CompetencyOutcome.D);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should not find a dangerous fault if none exists', () => {
+      const data: CatD1EUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatD1E(data, CompetencyOutcome.D);
+      expect(result.length).toBe(0);
+    });
+
+    it('should find a serious fault if one exists', () => {
+      const data: CatD1EUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.S,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatD1E(data, CompetencyOutcome.S);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should not find a serious fault if none exist', () => {
+      const data: CatD1EUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatD1E(data, CompetencyOutcome.S);
+      expect(result.length).toBe(0);
+    });
+
+    it('should find a driving fault if one exists', () => {
+      const data: CatD1EUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatD1E(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should return a serious fault when 5 vehicle check driving faults', () => {
+      const vehicleChecks: CatD1EUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        },
+          {
+            code: 'S02',
+            description: 'S02',
+            outcome: CompetencyOutcome.DF,
+          },
+          {
+            code: 'S03',
+            description: 'S03',
+            outcome: CompetencyOutcome.DF,
+          }],
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        },
+          {
+            code: 'T02',
+            description: 'T02',
+            outcome: CompetencyOutcome.DF,
+          }],
+      };
+      const data: CatD1EUniqueTypes.TestData = {
+        vehicleChecks,
+        seriousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.S,
+          },
+        },
+      };
+      const result: Fault[] = getSeriousFaultsCatD1E(data);
+      expect(result.length).toBe(3);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+
+    it('should only return one driving fault with a count of two if two exist', () => {
+      const data: CatD1EUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+
+      const result: Fault[] = getVehicleChecksFaultCatD1E(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 2 });
+    });
+
+    it('should return one driving fault with a count of 1', () => {
+      const data: CatD1EUniqueTypes.VehicleChecks = {
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatD1E(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+  });
+
+  describe('getDangerousFaultsCatD1E', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatD1EUniqueTypes.TestData = {
+        dangerousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.D,
+          },
+        },
+      };
+      const result: Fault [] = getDangerousFaultsCatD1E(data);
+      expect(result.length).toBe(2);
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+  });
+
+  describe('getSeriousFaultsCatD1E', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatD1EUniqueTypes.TestData = {
+        seriousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.S,
+          },
+        },
+      };
+
+      const result: Fault [] = getSeriousFaultsCatD1E(data);
+      expect(result.length).toBe(2);
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+  });
+
+  describe('getDrivingFaultsCatD1E', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatD1EUniqueTypes.TestData = {
+        drivingFaults: {
+          ancillaryControls: 1,
+          awarenessPlanning: 0,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.DF,
+          },
+        },
+      };
+      const result: Fault [] = getDrivingFaultsCatD1E(data);
+
+      expect(result.length).toBe(2);
+      expect(result).toEqual([
+                               { name: Competencies.ancillaryControls, count: 1 },
+                               { name: Competencies.reverseLeftControl, count: 1 },
+      ]);
+    });
+  });
+
+  describe('getNonStandardFaultsCatD1E', () => {
+    it('should return the uncouple competency when fault type is same to fault passed in and it was selected', () => {
+      const data: CatD1EUniqueTypes.TestData = {
+        uncoupleRecouple: {
+          fault: 'DF',
+          faultComments: 'some comment',
+          selected: true,
+        },
+        vehicleChecks: {},
+        manoeuvres: {},
+      };
+      const result: Fault[] = getNonStandardFaultsCatD1E(data, CompetencyOutcome.DF);
+      expect(result).toContain({ name: Competencies.uncoupleRecouple, count: 1 });
+    });
+
+    it('should return an empty array when the selected value is false', () => {
+      const data: CatD1EUniqueTypes.TestData = {
+        uncoupleRecouple: {
+          fault: 'DF',
+          faultComments: 'some comment',
+          selected: false,
+        },
+      };
+      const result: Fault[] = getNonStandardFaultsCatD1E(data, CompetencyOutcome.DF);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/functions/sendCandidateResults/application/service/categories/D1E/__tests__/fault-provider-cat-d1e.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/D1E/__tests__/fault-provider-cat-d1e.spec.ts
@@ -81,27 +81,12 @@ describe('fault-provider-cat-d1e', () => {
           code: 'S01',
           description: 'S01',
           outcome: CompetencyOutcome.DF,
-        },
-          {
-            code: 'S02',
-            description: 'S02',
-            outcome: CompetencyOutcome.DF,
-          },
-          {
-            code: 'S03',
-            description: 'S03',
-            outcome: CompetencyOutcome.DF,
-          }],
+        }],
         tellMeQuestions: [{
           code: 'T01',
           description: 'T01',
           outcome: CompetencyOutcome.DF,
-        },
-          {
-            code: 'T02',
-            description: 'T02',
-            outcome: CompetencyOutcome.DF,
-          }],
+        }],
       };
       const data: CatD1EUniqueTypes.TestData = {
         vehicleChecks,
@@ -139,7 +124,7 @@ describe('fault-provider-cat-d1e', () => {
 
       const result: Fault[] = getVehicleChecksFaultCatD1E(data, CompetencyOutcome.DF);
       expect(result.length).toBe(1);
-      expect(result).toContain({ name: Competencies.vehicleChecks, count: 2 });
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
     });
 
     it('should return one driving fault with a count of 1', () => {

--- a/src/functions/sendCandidateResults/application/service/categories/D1E/fault-provider-cat-d1e.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/D1E/fault-provider-cat-d1e.ts
@@ -1,6 +1,6 @@
 import { CatD1EUniqueTypes } from '@dvsa/mes-test-schema/categories/D1E';
 import { QuestionOutcome, QuestionResult } from '@dvsa/mes-test-schema/categories/common';
-import { Fault } from '../../../../domain/fault';
+import { Fault, FaultLimit } from '../../../../domain/fault';
 import { CompetencyOutcome } from '../../../../domain/competency-outcome';
 import {
   convertBooleanFaultObjectToArray,
@@ -42,8 +42,8 @@ export const getSeriousFaultsCatD1E = (testData: CatD1EUniqueTypes.TestData | un
   getNonStandardFaultsCatD1E(testData, CompetencyOutcome.S)
     .forEach(fault => seriousFaults.push(fault));
 
-  if (
-    getVehicleCheckFaultCount(testData.vehicleChecks as CatD1EUniqueTypes.VehicleChecks, CompetencyOutcome.DF) === 5) {
+  if (getVehicleCheckFaultCount(testData.vehicleChecks as CatD1EUniqueTypes.VehicleChecks, CompetencyOutcome.DF)
+    === FaultLimit.TRAILER) {
     seriousFaults.push({ name: Competencies.vehicleChecks, count: 1 });
   }
 
@@ -122,7 +122,9 @@ export const getVehicleChecksFaultCatD1E = (
   const faultCount = getVehicleCheckFaultCount(vehicleChecks, faultType);
 
   if (faultCount > 0) {
-    faultArray.push({ name: Competencies.vehicleChecks, count: faultCount === 5 ? 4 : faultCount });
+    faultArray.push(
+      { name: Competencies.vehicleChecks, count: faultCount === FaultLimit.TRAILER ? 1 : faultCount },
+    );
   }
   return faultArray;
 };

--- a/src/functions/sendCandidateResults/application/service/categories/D1E/fault-provider-cat-d1e.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/D1E/fault-provider-cat-d1e.ts
@@ -1,0 +1,128 @@
+import { CatD1EUniqueTypes } from '@dvsa/mes-test-schema/categories/D1E';
+import { QuestionOutcome, QuestionResult } from '@dvsa/mes-test-schema/categories/common';
+import { Fault } from '../../../../domain/fault';
+import { CompetencyOutcome } from '../../../../domain/competency-outcome';
+import {
+  convertBooleanFaultObjectToArray,
+  convertNumericFaultObjectToArray,
+  getCompletedManoeuvres,
+} from '../../fault-provider';
+import { Competencies } from '../../../../domain/competencies';
+
+export const getDrivingFaultsCatD1E = (testData: CatD1EUniqueTypes.TestData | undefined): Fault [] => {
+  const drivingFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.drivingFaults) {
+    convertNumericFaultObjectToArray(testData.drivingFaults)
+      .forEach(fault => drivingFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatD1E(testData, CompetencyOutcome.DF)
+    .forEach(fault => drivingFaults.push(fault));
+
+  return drivingFaults;
+};
+
+export const getSeriousFaultsCatD1E = (testData: CatD1EUniqueTypes.TestData | undefined): Fault [] => {
+  const seriousFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.seriousFaults) {
+    convertBooleanFaultObjectToArray(testData.seriousFaults)
+      .forEach(fault => seriousFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatD1E(testData, CompetencyOutcome.S)
+    .forEach(fault => seriousFaults.push(fault));
+
+  if (
+    getVehicleCheckFaultCount(testData.vehicleChecks as CatD1EUniqueTypes.VehicleChecks, CompetencyOutcome.DF) === 5) {
+    seriousFaults.push({ name: Competencies.vehicleChecks, count: 1 });
+  }
+
+  return seriousFaults;
+};
+
+const getVehicleCheckFaultCount = (
+  vehicleChecks: CatD1EUniqueTypes.VehicleChecks,
+  faultType: QuestionOutcome): number => {
+  let questionCount: number = 0;
+
+  if (vehicleChecks) {
+    if (vehicleChecks.showMeQuestions) {
+      questionCount = questionCount +
+        vehicleChecks.showMeQuestions.filter((showMe: QuestionResult) => showMe.outcome === faultType).length;
+    }
+    if (vehicleChecks.tellMeQuestions) {
+      questionCount = questionCount +
+        vehicleChecks.tellMeQuestions.filter((tellMe: QuestionResult) => tellMe.outcome === faultType).length;
+    }
+  }
+  return questionCount;
+};
+
+export const getDangerousFaultsCatD1E = (testData: CatD1EUniqueTypes.TestData | undefined): Fault [] => {
+  const dangerousFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.dangerousFaults) {
+    convertBooleanFaultObjectToArray(testData.dangerousFaults)
+      .forEach(fault => dangerousFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatD1E(testData, CompetencyOutcome.D)
+    .forEach(fault => dangerousFaults.push(fault));
+
+  return dangerousFaults;
+};
+
+export const getNonStandardFaultsCatD1E = (
+  testData: CatD1EUniqueTypes.TestData,
+  faultType: CompetencyOutcome): Fault[] => {
+
+  const faults: Fault[] = [];
+
+// Uncouple / recouple
+  if (
+    testData.uncoupleRecouple &&
+    testData.uncoupleRecouple.selected &&
+    testData.uncoupleRecouple.fault === faultType) {
+    faults.push({ name: Competencies.uncoupleRecouple, count: 1 });
+  }
+
+// Manoeuvres
+  if (testData.manoeuvres) {
+    getCompletedManoeuvres(testData.manoeuvres, faultType)
+      .forEach(fault => faults.push(fault));
+  }
+
+// Vehicle Checks
+  if (testData.vehicleChecks) {
+    getVehicleChecksFaultCatD1E(testData.vehicleChecks, faultType)
+      .forEach(fault => faults.push(fault));
+  }
+
+  return faults;
+};
+
+export const getVehicleChecksFaultCatD1E = (
+  vehicleChecks: CatD1EUniqueTypes.VehicleChecks,
+  faultType: QuestionOutcome): Fault[] => {
+  const faultArray: Fault[] = [];
+  const faultCount = getVehicleCheckFaultCount(vehicleChecks, faultType);
+
+  if (faultCount > 0) {
+    faultArray.push({ name: Competencies.vehicleChecks, count: faultCount === 5 ? 4 : faultCount });
+  }
+  return faultArray;
+};

--- a/src/functions/sendCandidateResults/application/service/categories/DE/__tests__/fault-provider-cat-de.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/DE/__tests__/fault-provider-cat-de.spec.ts
@@ -1,0 +1,253 @@
+import { CatDEUniqueTypes } from '@dvsa/mes-test-schema/categories/DE';
+import { CompetencyOutcome } from '../../../../../domain/competency-outcome';
+import { Fault } from '../../../../../domain/fault';
+import {
+  getDangerousFaultsCatDE,
+  getDrivingFaultsCatDE,
+  getNonStandardFaultsCatDE,
+  getSeriousFaultsCatDE,
+  getVehicleChecksFaultCatDE,
+} from '../fault-provider-cat-de';
+import { Competencies } from '../../../../../domain/competencies';
+
+describe('fault-provider-cat-de', () => {
+  describe('getVehicleChecksFaultCatDE', () => {
+    it('should find a dangerous fault if one exists', () => {
+      const data: CatDEUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.D,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatDE(data, CompetencyOutcome.D);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should not find a dangerous fault if none exists', () => {
+      const data: CatDEUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatDE(data, CompetencyOutcome.D);
+      expect(result.length).toBe(0);
+    });
+
+    it('should find a serious fault if one exists', () => {
+      const data: CatDEUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.S,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatDE(data, CompetencyOutcome.S);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should not find a serious fault if none exist', () => {
+      const data: CatDEUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatDE(data, CompetencyOutcome.S);
+      expect(result.length).toBe(0);
+    });
+
+    it('should find a driving fault if one exists', () => {
+      const data: CatDEUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatDE(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+
+    it('should return a serious fault when 5 vehicle check driving faults', () => {
+      const vehicleChecks: CatDEUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        },
+          {
+            code: 'S02',
+            description: 'S02',
+            outcome: CompetencyOutcome.DF,
+          },
+          {
+            code: 'S03',
+            description: 'S03',
+            outcome: CompetencyOutcome.DF,
+          }],
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        },
+          {
+            code: 'T02',
+            description: 'T02',
+            outcome: CompetencyOutcome.DF,
+          }],
+      };
+      const data: CatDEUniqueTypes.TestData = {
+        vehicleChecks,
+        seriousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.S,
+          },
+        },
+      };
+      const result: Fault[] = getSeriousFaultsCatDE(data);
+      expect(result.length).toBe(3);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+
+    it('should only return one driving fault with a count of two if two exist', () => {
+      const data: CatDEUniqueTypes.VehicleChecks = {
+        showMeQuestions: [{
+          code: 'S01',
+          description: 'S01',
+          outcome: CompetencyOutcome.DF,
+        }],
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+
+      const result: Fault[] = getVehicleChecksFaultCatDE(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 2 });
+    });
+
+    it('should return one driving fault with a count of 1', () => {
+      const data: CatDEUniqueTypes.VehicleChecks = {
+        tellMeQuestions: [{
+          code: 'T01',
+          description: 'T01',
+          outcome: CompetencyOutcome.DF,
+        }],
+      };
+      const result: Fault[] = getVehicleChecksFaultCatDE(data, CompetencyOutcome.DF);
+      expect(result.length).toBe(1);
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
+    });
+  });
+
+  describe('getDangerousFaultsCatDE', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatDEUniqueTypes.TestData = {
+        dangerousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.D,
+          },
+        },
+      };
+      const result: Fault [] = getDangerousFaultsCatDE(data);
+      expect(result.length).toBe(2);
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+  });
+
+  describe('getSeriousFaultsCatDE', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatDEUniqueTypes.TestData = {
+        seriousFaults: {
+          ancillaryControls: true,
+          awarenessPlanning: false,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.S,
+          },
+        },
+      };
+
+      const result: Fault [] = getSeriousFaultsCatDE(data);
+      expect(result.length).toBe(2);
+      expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
+      expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+    });
+  });
+
+  describe('getDrivingFaultsCatDE', () => {
+    it('should give us a list of faults from different sections of the test data', () => {
+      const data: CatDEUniqueTypes.TestData = {
+        drivingFaults: {
+          ancillaryControls: 1,
+          awarenessPlanning: 0,
+        },
+        manoeuvres: {
+          reverseLeft: {
+            selected: true,
+            controlFault: CompetencyOutcome.DF,
+          },
+        },
+      };
+      const result: Fault [] = getDrivingFaultsCatDE(data);
+
+      expect(result.length).toBe(2);
+      expect(result).toEqual([
+        { name: Competencies.ancillaryControls, count: 1 },
+        { name: Competencies.reverseLeftControl, count: 1 },
+      ]);
+    });
+  });
+
+  describe('getNonStandardFaultsCatDE', () => {
+    it('should return the uncouple competency when fault type is same to fault passed in and it was selected', () => {
+      const data: CatDEUniqueTypes.TestData = {
+        uncoupleRecouple: {
+          fault: 'DF',
+          faultComments: 'some comment',
+          selected: true,
+        },
+        vehicleChecks: {},
+        manoeuvres: {},
+      };
+      const result: Fault[] = getNonStandardFaultsCatDE(data, CompetencyOutcome.DF);
+      expect(result).toContain({ name: Competencies.uncoupleRecouple, count: 1 });
+    });
+
+    it('should return an empty array when the selected value is false', () => {
+      const data: CatDEUniqueTypes.TestData = {
+        uncoupleRecouple: {
+          fault: 'DF',
+          faultComments: 'some comment',
+          selected: false,
+        },
+      };
+      const result: Fault[] = getNonStandardFaultsCatDE(data, CompetencyOutcome.DF);
+      expect(result).toEqual([]);
+    });
+  });
+});

--- a/src/functions/sendCandidateResults/application/service/categories/DE/__tests__/fault-provider-cat-de.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/DE/__tests__/fault-provider-cat-de.spec.ts
@@ -81,27 +81,12 @@ describe('fault-provider-cat-de', () => {
           code: 'S01',
           description: 'S01',
           outcome: CompetencyOutcome.DF,
-        },
-          {
-            code: 'S02',
-            description: 'S02',
-            outcome: CompetencyOutcome.DF,
-          },
-          {
-            code: 'S03',
-            description: 'S03',
-            outcome: CompetencyOutcome.DF,
-          }],
+        }],
         tellMeQuestions: [{
           code: 'T01',
           description: 'T01',
           outcome: CompetencyOutcome.DF,
-        },
-          {
-            code: 'T02',
-            description: 'T02',
-            outcome: CompetencyOutcome.DF,
-          }],
+        }],
       };
       const data: CatDEUniqueTypes.TestData = {
         vehicleChecks,
@@ -139,7 +124,7 @@ describe('fault-provider-cat-de', () => {
 
       const result: Fault[] = getVehicleChecksFaultCatDE(data, CompetencyOutcome.DF);
       expect(result.length).toBe(1);
-      expect(result).toContain({ name: Competencies.vehicleChecks, count: 2 });
+      expect(result).toContain({ name: Competencies.vehicleChecks, count: 1 });
     });
 
     it('should return one driving fault with a count of 1', () => {

--- a/src/functions/sendCandidateResults/application/service/categories/DE/fault-provider-cat-de.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/DE/fault-provider-cat-de.ts
@@ -1,0 +1,128 @@
+import { CatDEUniqueTypes } from '@dvsa/mes-test-schema/categories/DE';
+import { QuestionOutcome, QuestionResult } from '@dvsa/mes-test-schema/categories/common';
+import { Fault } from '../../../../domain/fault';
+import { CompetencyOutcome } from '../../../../domain/competency-outcome';
+import {
+  convertBooleanFaultObjectToArray,
+  convertNumericFaultObjectToArray,
+  getCompletedManoeuvres,
+} from '../../fault-provider';
+import { Competencies } from '../../../../domain/competencies';
+
+export const getDrivingFaultsCatDE = (testData: CatDEUniqueTypes.TestData | undefined): Fault [] => {
+  const drivingFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.drivingFaults) {
+    convertNumericFaultObjectToArray(testData.drivingFaults)
+      .forEach(fault => drivingFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatDE(testData, CompetencyOutcome.DF)
+    .forEach(fault => drivingFaults.push(fault));
+
+  return drivingFaults;
+};
+
+export const getSeriousFaultsCatDE = (testData: CatDEUniqueTypes.TestData | undefined): Fault [] => {
+  const seriousFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.seriousFaults) {
+    convertBooleanFaultObjectToArray(testData.seriousFaults)
+      .forEach(fault => seriousFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatDE(testData, CompetencyOutcome.S)
+    .forEach(fault => seriousFaults.push(fault));
+
+  if (
+    getVehicleCheckFaultCount(testData.vehicleChecks as CatDEUniqueTypes.VehicleChecks, CompetencyOutcome.DF) === 5) {
+    seriousFaults.push({ name: Competencies.vehicleChecks, count: 1 });
+  }
+
+  return seriousFaults;
+};
+
+const getVehicleCheckFaultCount = (
+  vehicleChecks: CatDEUniqueTypes.VehicleChecks,
+  faultType: QuestionOutcome): number => {
+  let questionCount: number = 0;
+
+  if (vehicleChecks) {
+    if (vehicleChecks.showMeQuestions) {
+      questionCount = questionCount +
+        vehicleChecks.showMeQuestions.filter((showMe: QuestionResult) => showMe.outcome === faultType).length;
+    }
+    if (vehicleChecks.tellMeQuestions) {
+      questionCount = questionCount +
+        vehicleChecks.tellMeQuestions.filter((tellMe: QuestionResult) => tellMe.outcome === faultType).length;
+    }
+  }
+  return questionCount;
+};
+
+export const getDangerousFaultsCatDE = (testData: CatDEUniqueTypes.TestData | undefined): Fault [] => {
+  const dangerousFaults: Fault[] = [];
+
+  if (!testData) {
+    throw new Error('No Test Data');
+  }
+
+  if (testData.dangerousFaults) {
+    convertBooleanFaultObjectToArray(testData.dangerousFaults)
+      .forEach(fault => dangerousFaults.push(fault));
+  }
+
+  getNonStandardFaultsCatDE(testData, CompetencyOutcome.D)
+    .forEach(fault => dangerousFaults.push(fault));
+
+  return dangerousFaults;
+};
+
+export const getNonStandardFaultsCatDE = (
+  testData: CatDEUniqueTypes.TestData,
+  faultType: CompetencyOutcome): Fault[] => {
+
+  const faults: Fault[] = [];
+
+// Uncouple / recouple
+  if (
+    testData.uncoupleRecouple &&
+    testData.uncoupleRecouple.selected &&
+    testData.uncoupleRecouple.fault === faultType) {
+    faults.push({ name: Competencies.uncoupleRecouple, count: 1 });
+  }
+
+// Manoeuvres
+  if (testData.manoeuvres) {
+    getCompletedManoeuvres(testData.manoeuvres, faultType)
+      .forEach(fault => faults.push(fault));
+  }
+
+// Vehicle Checks
+  if (testData.vehicleChecks) {
+    getVehicleChecksFaultCatDE(testData.vehicleChecks, faultType)
+      .forEach(fault => faults.push(fault));
+  }
+
+  return faults;
+};
+
+export const getVehicleChecksFaultCatDE = (
+  vehicleChecks: CatDEUniqueTypes.VehicleChecks,
+  faultType: QuestionOutcome): Fault[] => {
+  const faultArray: Fault[] = [];
+  const faultCount = getVehicleCheckFaultCount(vehicleChecks, faultType);
+
+  if (faultCount > 0) {
+    faultArray.push({ name: Competencies.vehicleChecks, count: faultCount === 5 ? 4 : faultCount });
+  }
+  return faultArray;
+};

--- a/src/functions/sendCandidateResults/application/service/categories/DE/fault-provider-cat-de.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/DE/fault-provider-cat-de.ts
@@ -1,6 +1,6 @@
 import { CatDEUniqueTypes } from '@dvsa/mes-test-schema/categories/DE';
 import { QuestionOutcome, QuestionResult } from '@dvsa/mes-test-schema/categories/common';
-import { Fault } from '../../../../domain/fault';
+import { Fault, FaultLimit } from '../../../../domain/fault';
 import { CompetencyOutcome } from '../../../../domain/competency-outcome';
 import {
   convertBooleanFaultObjectToArray,
@@ -42,8 +42,8 @@ export const getSeriousFaultsCatDE = (testData: CatDEUniqueTypes.TestData | unde
   getNonStandardFaultsCatDE(testData, CompetencyOutcome.S)
     .forEach(fault => seriousFaults.push(fault));
 
-  if (
-    getVehicleCheckFaultCount(testData.vehicleChecks as CatDEUniqueTypes.VehicleChecks, CompetencyOutcome.DF) === 5) {
+  if (getVehicleCheckFaultCount(testData.vehicleChecks as CatDEUniqueTypes.VehicleChecks, CompetencyOutcome.DF)
+    === FaultLimit.TRAILER) {
     seriousFaults.push({ name: Competencies.vehicleChecks, count: 1 });
   }
 
@@ -122,7 +122,9 @@ export const getVehicleChecksFaultCatDE = (
   const faultCount = getVehicleCheckFaultCount(vehicleChecks, faultType);
 
   if (faultCount > 0) {
-    faultArray.push({ name: Competencies.vehicleChecks, count: faultCount === 5 ? 4 : faultCount });
+    faultArray.push(
+      { name: Competencies.vehicleChecks, count: faultCount === FaultLimit.TRAILER ? 1 : faultCount },
+    );
   }
   return faultArray;
 };

--- a/src/functions/sendCandidateResults/application/service/fault-provider.ts
+++ b/src/functions/sendCandidateResults/application/service/fault-provider.ts
@@ -1,3 +1,4 @@
+import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 import { TestData, ManoeuvreOutcome } from '@dvsa/mes-test-schema/categories/common';
 import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE';
@@ -5,9 +6,12 @@ import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
 import { CatCEUniqueTypes } from '@dvsa/mes-test-schema/categories/CE';
 import { CatC1UniqueTypes } from '@dvsa/mes-test-schema/categories/C1';
 import { CatC1EUniqueTypes } from '@dvsa/mes-test-schema/categories/C1E';
+import { CatDUniqueTypes } from '@dvsa/mes-test-schema/categories/D';
+import { CatDEUniqueTypes } from '@dvsa/mes-test-schema/categories/DE';
+import { CatD1UniqueTypes } from '@dvsa/mes-test-schema/categories/D1';
+import { CatD1EUniqueTypes } from '@dvsa/mes-test-schema/categories/D1E';
 import { Fault } from '../../domain/fault';
 import { Competencies } from '../../domain/competencies';
-import { TestCategory } from '@dvsa/mes-test-schema/category-definitions/common/test-category';
 import { injectable } from 'inversify';
 import 'reflect-metadata';
 import {
@@ -40,6 +44,26 @@ import {
   getDrivingFaultsCatC1E,
   getSeriousFaultsCatC1E,
 } from './categories/C1E/fault-provider-cat-c1e';
+import {
+  getDangerousFaultsCatD,
+  getDrivingFaultsCatD,
+  getSeriousFaultsCatD,
+} from './categories/D/fault-provider-cat-d';
+import {
+  getDangerousFaultsCatD1,
+  getDrivingFaultsCatD1,
+  getSeriousFaultsCatD1,
+} from './categories/D1/fault-provider-cat-d1';
+import {
+  getDangerousFaultsCatDE,
+  getDrivingFaultsCatDE,
+  getSeriousFaultsCatDE,
+} from './categories/DE/fault-provider-cat-de';
+import {
+  getDangerousFaultsCatD1E,
+  getDrivingFaultsCatD1E,
+  getSeriousFaultsCatD1E,
+} from './categories/D1E/fault-provider-cat-d1e';
 
 export interface IFaultProvider {
   getDrivingFaults(testData: TestData | undefined, category: string): Fault[];
@@ -54,58 +78,49 @@ export class FaultProvider implements IFaultProvider {
 
   public getDrivingFaults(testData: TestData | undefined, category: string): Fault[] {
     switch (category) {
-      case TestCategory.B:
-        return getDrivingFaultsCatB(testData as CatBUniqueTypes.TestData);
-      case TestCategory.BE:
-        return getDrivingFaultsCatBE(testData as CatBEUniqueTypes.TestData);
-      case TestCategory.C:
-        return getDrivingFaultsCatC(testData as CatCUniqueTypes.TestData);
-      case TestCategory.C1:
-        return getDrivingFaultsCatC1(testData as CatC1UniqueTypes.TestData);
-      case TestCategory.CE:
-        return getDrivingFaultsCatCE(testData as CatCEUniqueTypes.TestData);
-      case TestCategory.C1E:
-        return getDrivingFaultsCatC1E(testData as CatC1EUniqueTypes.TestData);
-      default:
-        return getDrivingFaultsCatB(testData as CatBUniqueTypes.TestData);
+      case TestCategory.B: return getDrivingFaultsCatB(testData as CatBUniqueTypes.TestData);
+      case TestCategory.BE: return getDrivingFaultsCatBE(testData as CatBEUniqueTypes.TestData);
+      case TestCategory.C: return getDrivingFaultsCatC(testData as CatCUniqueTypes.TestData);
+      case TestCategory.C1: return getDrivingFaultsCatC1(testData as CatC1UniqueTypes.TestData);
+      case TestCategory.CE: return getDrivingFaultsCatCE(testData as CatCEUniqueTypes.TestData);
+      case TestCategory.C1E: return getDrivingFaultsCatC1E(testData as CatC1EUniqueTypes.TestData);
+      case TestCategory.D: return getDrivingFaultsCatD(testData as CatDUniqueTypes.TestData);
+      case TestCategory.D1: return getDrivingFaultsCatD1(testData as CatD1UniqueTypes.TestData);
+      case TestCategory.DE: return getDrivingFaultsCatDE(testData as CatDEUniqueTypes.TestData);
+      case TestCategory.D1E: return getDrivingFaultsCatD1E(testData as CatD1EUniqueTypes.TestData);
+      default: return getDrivingFaultsCatB(testData as CatBUniqueTypes.TestData);
     }
   }
 
   public getSeriousFaults(testData: TestData | undefined, category: string): Fault[] {
     switch (category) {
-      case TestCategory.B:
-        return getSeriousFaultsCatB(testData as CatBUniqueTypes.TestData);
-      case TestCategory.BE:
-        return getSeriousFaultsCatBE(testData as CatBEUniqueTypes.TestData);
-      case TestCategory.C:
-        return getSeriousFaultsCatC(testData as CatCUniqueTypes.TestData);
-      case TestCategory.C1:
-        return getSeriousFaultsCatC1(testData as CatC1UniqueTypes.TestData);
-      case TestCategory.CE:
-        return getSeriousFaultsCatCE(testData as CatCEUniqueTypes.TestData);
-      case TestCategory.C1E:
-        return getSeriousFaultsCatC1E(testData as CatC1EUniqueTypes.TestData);
-      default:
-        return getSeriousFaultsCatB(testData as CatBUniqueTypes.TestData);
+      case TestCategory.B: return getSeriousFaultsCatB(testData as CatBUniqueTypes.TestData);
+      case TestCategory.BE: return getSeriousFaultsCatBE(testData as CatBEUniqueTypes.TestData);
+      case TestCategory.C: return getSeriousFaultsCatC(testData as CatCUniqueTypes.TestData);
+      case TestCategory.C1: return getSeriousFaultsCatC1(testData as CatC1UniqueTypes.TestData);
+      case TestCategory.CE: return getSeriousFaultsCatCE(testData as CatCEUniqueTypes.TestData);
+      case TestCategory.C1E: return getSeriousFaultsCatC1E(testData as CatC1EUniqueTypes.TestData);
+      case TestCategory.D: return getSeriousFaultsCatD(testData as CatDUniqueTypes.TestData);
+      case TestCategory.D1: return getSeriousFaultsCatD1(testData as CatD1UniqueTypes.TestData);
+      case TestCategory.DE: return getSeriousFaultsCatDE(testData as CatDEUniqueTypes.TestData);
+      case TestCategory.D1E: return getSeriousFaultsCatD1E(testData as CatD1EUniqueTypes.TestData);
+      default: return getSeriousFaultsCatB(testData as CatBUniqueTypes.TestData);
     }
   }
 
   public getDangerousFaults(testData: TestData | undefined, category: string): Fault [] {
     switch (category) {
-      case TestCategory.B:
-        return getDangerousFaultsCatB(testData as CatBUniqueTypes.TestData);
-      case TestCategory.BE:
-        return getDangerousFaultsCatBE(testData as CatBEUniqueTypes.TestData);
-      case TestCategory.C:
-        return getDangerousFaultsCatC(testData as CatCUniqueTypes.TestData);
-      case TestCategory.C1:
-        return getDangerousFaultsCatC1(testData as CatC1UniqueTypes.TestData);
-      case TestCategory.CE:
-        return getDangerousFaultsCatCE(testData as CatCEUniqueTypes.TestData);
-      case TestCategory.C1E:
-        return getDangerousFaultsCatC1E(testData as CatC1EUniqueTypes.TestData);
-      default:
-        return getDangerousFaultsCatB(testData as CatBUniqueTypes.TestData);
+      case TestCategory.B: return getDangerousFaultsCatB(testData as CatBUniqueTypes.TestData);
+      case TestCategory.BE: return getDangerousFaultsCatBE(testData as CatBEUniqueTypes.TestData);
+      case TestCategory.C: return getDangerousFaultsCatC(testData as CatCUniqueTypes.TestData);
+      case TestCategory.C1: return getDangerousFaultsCatC1(testData as CatC1UniqueTypes.TestData);
+      case TestCategory.CE: return getDangerousFaultsCatCE(testData as CatCEUniqueTypes.TestData);
+      case TestCategory.C1E: return getDangerousFaultsCatC1E(testData as CatC1EUniqueTypes.TestData);
+      case TestCategory.D: return getDangerousFaultsCatD(testData as CatDUniqueTypes.TestData);
+      case TestCategory.D1: return getDangerousFaultsCatD1(testData as CatD1UniqueTypes.TestData);
+      case TestCategory.DE: return getDangerousFaultsCatDE(testData as CatDEUniqueTypes.TestData);
+      case TestCategory.D1E: return getDangerousFaultsCatD1E(testData as CatD1EUniqueTypes.TestData);
+      default: return getDangerousFaultsCatB(testData as CatBUniqueTypes.TestData);
     }
   }
 }

--- a/src/functions/sendCandidateResults/application/service/template-id-provider.ts
+++ b/src/functions/sendCandidateResults/application/service/template-id-provider.ts
@@ -60,6 +60,10 @@ export function isVocationalCategory(category: CategoryCode): boolean {
     TestCategory.CE,
     TestCategory.C1,
     TestCategory.C1E,
+    TestCategory.D,
+    TestCategory.DE,
+    TestCategory.D1,
+    TestCategory.D1E,
   ].includes(category as TestCategory);
 }
 


### PR DESCRIPTION
Added fault providers for Cat D and all sub categories, added Cat D and subcategories to the vocational array in order to return the correct notify template string