### PR TITLE
release/MES-5268 Fix Control Stop Faults Not Showing Up Home Tests

### DIFF
--- a/src/functions/sendCandidateResults/application/service/categories/Home/__tests__/fault-provider-cat-home.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/Home/__tests__/fault-provider-cat-home.spec.ts
@@ -23,11 +23,16 @@ describe('fault-provider-cat-home', () => {
             controlFault: CompetencyOutcome.D,
           },
         },
+        controlledStop: {
+          selected: true,
+          fault: CompetencyOutcome.D,
+        },
       };
       const result: Fault [] = getDangerousFaultsCatHome(data);
-      expect(result.length).toBe(2);
+      expect(result.length).toBe(3);
       expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
       expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
+      expect(result).toContain({ name: Competencies.controlledStop, count: 1 });
     });
   });
 
@@ -48,13 +53,18 @@ describe('fault-provider-cat-home', () => {
           selected: true,
           seriousFault: true,
         },
+        controlledStop: {
+          selected: true,
+          fault: CompetencyOutcome.S,
+        },
       };
 
       const result: Fault [] = getSeriousFaultsCatHome(data);
-      expect(result.length).toBe(3);
+      expect(result.length).toBe(4);
       expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
       expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
       expect(result).toContain({ name: Competencies.highwayCodeSafety, count: 1 });
+      expect(result).toContain({ name: Competencies.controlledStop, count: 1 });
     });
   });
 
@@ -75,13 +85,18 @@ describe('fault-provider-cat-home', () => {
           selected: true,
           drivingFault: false,
         },
+        controlledStop: {
+          selected: true,
+          fault: CompetencyOutcome.DF,
+        },
       };
       const result: Fault [] = getDrivingFaultsCatHome(data);
 
-      expect(result.length).toBe(2);
+      expect(result.length).toBe(3);
       expect(result).toEqual([
-                               { name: Competencies.ancillaryControls, count: 1 },
-                               { name: Competencies.reverseLeftControl, count: 1 },
+        { name: Competencies.ancillaryControls, count: 1 },
+        { name: Competencies.reverseLeftControl, count: 1 },
+        { name: Competencies.controlledStop, count: 1 },
       ]);
     });
   });

--- a/src/functions/sendCandidateResults/application/service/categories/Home/fault-provider-cat-home.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/Home/fault-provider-cat-home.ts
@@ -9,11 +9,18 @@ import {
   convertBooleanFaultObjectToArray,
   convertNumericFaultObjectToArray,
   getCompletedManoeuvres,
-  getVehicleCheckFaultCount, HomeTestDataUnion,
+  getVehicleCheckFaultCount,
+  HomeTestDataUnion,
 } from '../../fault-provider';
 import { Competencies } from '../../../../domain/competencies';
+import { CatKUniqueTypes } from '@dvsa/mes-test-schema/categories/K';
+import { QuestionOutcome } from '@dvsa/mes-test-schema/categories/common';
 
 type HCodeSafetyFault = 'drivingFault' | 'seriousFault';
+export type ControlledStopHomeTestUnion = CatFUniqueTypes.ControlledStop
+| CatGUniqueTypes.ControlledStop
+| CatHUniqueTypes.ControlledStop
+| CatKUniqueTypes.ControlledStop;
 
 export const getDrivingFaultsCatHome = (testData: HomeTestDataUnion | undefined): Fault [] => {
   const drivingFaults: Fault[] = [];
@@ -33,6 +40,9 @@ export const getDrivingFaultsCatHome = (testData: HomeTestDataUnion | undefined)
 
   getNonStandardFaultsCatHome(testData, CompetencyOutcome.DF)
     .forEach((fault: Fault) => drivingFaults.push(fault));
+
+  getControlledStopFaultsCatHome(testData.controlledStop as ControlledStopHomeTestUnion, CompetencyOutcome.DF)
+    .forEach(fault => drivingFaults.push(fault));
 
   if (getVehicleCheckFaultCount(testData.vehicleChecks as CatFUniqueTypes.VehicleChecks, CompetencyOutcome.DF) >= 1) {
     drivingFaults.push({ name: Competencies.vehicleChecks, count: 1 });
@@ -60,6 +70,8 @@ export const getSeriousFaultsCatHome = (testData: HomeTestDataUnion | undefined)
   getNonStandardFaultsCatHome(testData, CompetencyOutcome.S)
     .forEach((fault: Fault) => seriousFaults.push(fault));
 
+  getControlledStopFaultsCatHome(testData.controlledStop as ControlledStopHomeTestUnion, CompetencyOutcome.S)
+    .forEach(fault => seriousFaults.push(fault));
   return seriousFaults;
 };
 
@@ -78,7 +90,15 @@ export const getDangerousFaultsCatHome = (testData: HomeTestDataUnion | undefine
   getNonStandardFaultsCatHome(testData, CompetencyOutcome.D)
     .forEach(fault => dangerousFaults.push(fault));
 
+  getControlledStopFaultsCatHome(testData.controlledStop as ControlledStopHomeTestUnion, CompetencyOutcome.D)
+    .forEach(fault => dangerousFaults.push(fault));
+
   return dangerousFaults;
+};
+
+export const getControlledStopFaultsCatHome = (controlledStop: ControlledStopHomeTestUnion,
+                                               faultType: QuestionOutcome): Fault[] => {
+  return (controlledStop.fault === faultType) ? [{ name: Competencies.controlledStop, count: 1 }] : [];
 };
 
 export const getNonStandardFaultsCatHome = (


### PR DESCRIPTION
Introduces logic which fixes the control stop faults not showing up in notify.

Screenshots:
<img width="1363" alt="Screenshot 2020-05-29 at 11 17 50" src="https://user-images.githubusercontent.com/28736958/83249161-0f311100-a19e-11ea-9100-4dfa5d9d66ce.png">
<img width="1392" alt="Screenshot 2020-05-29 at 11 19 28" src="https://user-images.githubusercontent.com/28736958/83249287-48698100-a19e-11ea-9fa8-a6e6c4fa79dc.png">
<img width="1423" alt="Screenshot 2020-05-29 at 11 20 33" src="https://user-images.githubusercontent.com/28736958/83249416-6e8f2100-a19e-11ea-8338-f4ea63f11aa3.png">
