### PR TITLE
release/MES-5269 Fix eyesight faults not showing up in email for Home/AM2 tests

### DIFF
--- a/src/functions/sendCandidateResults/application/service/categories/AM2/__tests__/fault-provider-cat-a-mod2.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/AM2/__tests__/fault-provider-cat-a-mod2.spec.ts
@@ -1,7 +1,7 @@
 import {
+  getDangerousFaultsCatAMod2,
   getDrivingFaultsCatAMod2,
   getSeriousFaultsCatAMod2,
-  getDangerousFaultsCatAMod2,
   hasQuestionFault,
 } from '../fault-provider-cat-a-mod2';
 
@@ -81,6 +81,7 @@ describe('Fault Provider Cat A Mod2', () => {
       expect(getSeriousFaultsCatAMod2(validTestData)).toEqual([
         { name: Competencies.useOfMirrorsChangeSpeed, count: 1 },
         { name: Competencies.signalsTimed, count: 1 },
+        { name: Competencies.eyesightTest, count: 1 },
       ]);
     });
   });

--- a/src/functions/sendCandidateResults/application/service/categories/AM2/fault-provider-cat-a-mod2.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/AM2/fault-provider-cat-a-mod2.ts
@@ -22,13 +22,19 @@ export const getDrivingFaultsCatAMod2 = (testData: CatAMod2TestData | undefined)
 
 export const getSeriousFaultsCatAMod2 = (testData: CatAMod2TestData | undefined): Fault[] => {
 
+  const seriousFaults: Fault[] = [];
+
   if (!testData) {
     throw new Error('No Test Data');
   }
 
-  return [
-    ...convertBooleanFaultObjectToArray(testData.seriousFaults),
-  ];
+  convertBooleanFaultObjectToArray(testData.seriousFaults).forEach(fault => seriousFaults.push(fault));
+
+  if (testData.eyesightTest && testData.eyesightTest.seriousFault) {
+    seriousFaults.push({ name: Competencies.eyesightTest, count: 1 });
+  }
+
+  return seriousFaults;
 };
 
 export const getDangerousFaultsCatAMod2 = (testData: CatAMod2TestData | undefined): Fault[] => {

--- a/src/functions/sendCandidateResults/application/service/categories/Home/__tests__/fault-provider-cat-home.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/Home/__tests__/fault-provider-cat-home.spec.ts
@@ -57,14 +57,18 @@ describe('fault-provider-cat-home', () => {
           selected: true,
           fault: CompetencyOutcome.S,
         },
+        eyesightTest: {
+          seriousFault: true,
+        },
       };
 
       const result: Fault [] = getSeriousFaultsCatHome(data);
-      expect(result.length).toBe(4);
+      expect(result.length).toBe(5);
       expect(result).toContain({ name: Competencies.ancillaryControls, count: 1 });
       expect(result).toContain({ name: Competencies.reverseLeftControl, count: 1 });
       expect(result).toContain({ name: Competencies.highwayCodeSafety, count: 1 });
       expect(result).toContain({ name: Competencies.controlledStop, count: 1 });
+      expect(result).toContain({ name: Competencies.eyesightTest, count: 1 });
     });
   });
 

--- a/src/functions/sendCandidateResults/application/service/categories/Home/fault-provider-cat-home.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/Home/fault-provider-cat-home.ts
@@ -72,6 +72,12 @@ export const getSeriousFaultsCatHome = (testData: HomeTestDataUnion | undefined)
 
   getControlledStopFaultsCatHome(testData.controlledStop as ControlledStopHomeTestUnion, CompetencyOutcome.S)
     .forEach(fault => seriousFaults.push(fault));
+
+  // eyesight test
+  if (testData.eyesightTest && testData.eyesightTest.seriousFault) {
+    seriousFaults.push({ name: Competencies.eyesightTest, count: 1 });
+  }
+
   return seriousFaults;
 };
 


### PR DESCRIPTION
Introduces logic to fix eyesight faults not showing up on NOTIFY email after completion of tests for Cat Home/AM2.

Screenshots:
<img width="1430" alt="Screenshot 2020-06-01 at 10 14 19" src="https://user-images.githubusercontent.com/28736958/83395216-cec9d100-a3f1-11ea-8665-4891c22020c4.png">
