### PR TITLE
MES-5431: Disable Notify for Delegated Tests

### DIFF
--- a/src/functions/sendCandidateResults/application/service/__mocks__/test-result-union.mock.ts
+++ b/src/functions/sendCandidateResults/application/service/__mocks__/test-result-union.mock.ts
@@ -1,0 +1,38 @@
+import { TestResultSchemasUnion } from '@dvsa/mes-test-schema/categories';
+
+const testResultUnionMock: TestResultSchemasUnion = {
+  version: 'version 1',
+  category: 'B',
+  activityCode: '1',
+  journalData: {
+    applicationReference: {
+      applicationId: 12345671,
+      bookingSequence: 1,
+      checkDigit: 1,
+    },
+    examiner: {
+      staffNumber: '123456',
+    },
+    testCentre: {
+      centreId: 123456,
+      costCode: '123456',
+      centreName: 'Test Centre 001',
+    },
+    testSlotAttributes: {
+      slotId: 123456,
+      vehicleTypeCode: 'B',
+      start: '2019-07-31T11:48:51',
+      welshTest: false,
+      specialNeeds: false,
+      extendedTest: false,
+    },
+    candidate: {},
+  },
+  rekey: false,
+  changeMarker: false,
+  examinerBooked: 12345678,
+  examinerConducted: 12345678,
+  examinerKeyed: 12345678,
+};
+
+export default testResultUnionMock;

--- a/src/functions/sendCandidateResults/application/service/__tests__/is-delegated-test.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/__tests__/is-delegated-test.spec.ts
@@ -1,10 +1,10 @@
-import { TestResultSchemasUnion } from '@dvsa/mes-test-schema/categories';
 import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
 import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE';
 import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
 import { CatC1UniqueTypes } from '@dvsa/mes-test-schema/categories/C1';
 import { CatC1EUniqueTypes } from '@dvsa/mes-test-schema/categories/C1E';
 import { CatCEUniqueTypes } from '@dvsa/mes-test-schema/categories/CE';
+import { TestResultCatCPCSchema } from '@dvsa/mes-test-schema/categories/CPC';
 import { CatDUniqueTypes } from '@dvsa/mes-test-schema/categories/D';
 import { CatD1UniqueTypes } from '@dvsa/mes-test-schema/categories/D1';
 import { CatD1EUniqueTypes } from '@dvsa/mes-test-schema/categories/D1E';
@@ -223,6 +223,52 @@ describe('is-delegated-test', () => {
     });
 
     it('should return false if delegatedTest is false', () => {
+      testResult.delegatedTest = false;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('examine category CCPC test result', () => {
+    const testResult: TestResultCatCPCSchema = {
+      ...(testResultUnionMock as TestResultCatCPCSchema),
+      category: 'CCPC',
+    };
+
+    it('should return true if delegatedTest is true', () => {
+      testResult.delegatedTest = true;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false if delegatedTes is false', () => {
+      testResult.delegatedTest = false;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('examine category DCPC test result', () => {
+    const testResult: TestResultCatCPCSchema = {
+      ...(testResultUnionMock as TestResultCatCPCSchema),
+      category: 'DCPC',
+    };
+
+    it('should return true if delegatedTest is true', () => {
+      testResult.delegatedTest = true;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false if delegatedTes is false', () => {
       testResult.delegatedTest = false;
 
       const result = isDelegatedTest(testResult);

--- a/src/functions/sendCandidateResults/application/service/__tests__/is-delegated-test.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/__tests__/is-delegated-test.spec.ts
@@ -1,6 +1,234 @@
+import { TestResultSchemasUnion } from '@dvsa/mes-test-schema/categories';
+import { CatBUniqueTypes } from '@dvsa/mes-test-schema/categories/B';
+import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE';
+import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
+import { CatC1UniqueTypes } from '@dvsa/mes-test-schema/categories/C1';
+import { CatC1EUniqueTypes } from '@dvsa/mes-test-schema/categories/C1E';
+import { CatCEUniqueTypes } from '@dvsa/mes-test-schema/categories/CE';
+import { CatDUniqueTypes } from '@dvsa/mes-test-schema/categories/D';
+import { CatD1UniqueTypes } from '@dvsa/mes-test-schema/categories/D1';
+import { CatD1EUniqueTypes } from '@dvsa/mes-test-schema/categories/D1E';
+import { CatDEUniqueTypes } from '@dvsa/mes-test-schema/categories/DE';
+import isDelegatedTest from '../is-delegated-test';
+import testResultUnionMock from '../__mocks__/test-result-union.mock';
 
 describe('is-delegated-test', () => {
-  describe('should return false when test category can not be a delegated test', () => {
+  it('should return false when test category can not be a delegated test', () => {
+    const testResult: CatBUniqueTypes.TestResult = {
+      ...(testResultUnionMock as CatBUniqueTypes.TestResult),
+      category: 'B',
+    };
 
+    const result = isDelegatedTest(testResult);
+
+    expect(result).toBe(false);
   });
+
+  describe('examine category B+E test result', () => {
+    const testResult: CatBEUniqueTypes.TestResult = {
+      ...(testResultUnionMock as CatBEUniqueTypes.TestResult),
+      category: 'B+E',
+    };
+
+    it('should return true if delegatedTest is true', () => {
+      testResult.delegatedTest = true;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false if delegatedTest is false', () => {
+      testResult.delegatedTest = false;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('examine category C test result', () => {
+    const testResult: CatCUniqueTypes.TestResult = {
+      ...(testResultUnionMock as CatCUniqueTypes.TestResult),
+      category: 'C',
+    };
+
+    it('should return true if delegatedTest is true', () => {
+      testResult.delegatedTest = true;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false if delegatedTest is false', () => {
+      testResult.delegatedTest = false;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('examine category C+E test result', () => {
+    const testResult: CatCEUniqueTypes.TestResult = {
+      ...(testResultUnionMock as CatCEUniqueTypes.TestResult),
+      category: 'C+E',
+    };
+
+    it('should return true if delegatedTest is true', () => {
+      testResult.delegatedTest = true;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false if delegatedTest is false', () => {
+      testResult.delegatedTest = false;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('examine category C1 test result', () => {
+    const testResult: CatC1UniqueTypes.TestResult = {
+      ...(testResultUnionMock as CatC1UniqueTypes.TestResult),
+      category: 'C1',
+    };
+
+    it('should return true if delegatedTest is true', () => {
+      testResult.delegatedTest = true;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false if delegatedTest is false', () => {
+      testResult.delegatedTest = false;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('examine category C1+E test result', () => {
+    const testResult: CatC1EUniqueTypes.TestResult = {
+      ...(testResultUnionMock as CatC1EUniqueTypes.TestResult),
+      category: 'C1+E',
+    };
+
+    it('should return true if delegatedTest is true', () => {
+      testResult.delegatedTest = true;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false if delegatedTest is false', () => {
+      testResult.delegatedTest = false;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('examine category D test result', () => {
+    const testResult: CatDUniqueTypes.TestResult = {
+      ...(testResultUnionMock as CatDUniqueTypes.TestResult),
+      category: 'D',
+    };
+
+    it('should return true if delegatedTest is true', () => {
+      testResult.delegatedTest = true;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false if delegatedTest is false', () => {
+      testResult.delegatedTest = false;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('examine category D+E test result', () => {
+    const testResult: CatDEUniqueTypes.TestResult = {
+      ...(testResultUnionMock as CatDEUniqueTypes.TestResult),
+      category: 'D+E',
+    };
+
+    it('should return true if delegatedTest is true', () => {
+      testResult.delegatedTest = true;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false if delegatedTest is false', () => {
+      testResult.delegatedTest = false;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('examine category D1 test result', () => {
+    const testResult: CatD1UniqueTypes.TestResult = {
+      ...(testResultUnionMock as CatD1UniqueTypes.TestResult),
+      category: 'D1',
+    };
+
+    it('should return true if delegatedTest is true', () => {
+      testResult.delegatedTest = true;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false if delegatedTest is false', () => {
+      testResult.delegatedTest = false;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('examine category D1+E test result', () => {
+    const testResult: CatD1EUniqueTypes.TestResult = {
+      ...(testResultUnionMock as CatD1EUniqueTypes.TestResult),
+      category: 'D1+E',
+    };
+
+    it('should return true if delegatedTest is true', () => {
+      testResult.delegatedTest = true;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(true);
+    });
+
+    it('should return false if delegatedTest is false', () => {
+      testResult.delegatedTest = false;
+
+      const result = isDelegatedTest(testResult);
+
+      expect(result).toBe(false);
+    });
+  });
+
 });

--- a/src/functions/sendCandidateResults/application/service/__tests__/is-delegated-test.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/__tests__/is-delegated-test.spec.ts
@@ -1,0 +1,6 @@
+
+describe('is-delegated-test', () => {
+  describe('should return false when test category can not be a delegated test', () => {
+
+  });
+});

--- a/src/functions/sendCandidateResults/application/service/is-delegated-test.ts
+++ b/src/functions/sendCandidateResults/application/service/is-delegated-test.ts
@@ -13,12 +13,12 @@ function isDelegatedTest(testResult: TestResultSchemasUnion): boolean {
     || testResult.category === 'D+E'
     || testResult.category === 'D1'
     || testResult.category === 'D1+E') {
-    return (testResult as TestResultCommonSchema).delegatedTest === true;
+    return (testResult as TestResultCommonSchema).delegatedTest || false;
   }
 
   if (testResult.category === 'CCPC'
     || testResult.category === 'DCPC') {
-    return (testResult as TestResultCatCPCSchema).delegatedTest === true;
+    return (testResult as TestResultCatCPCSchema).delegatedTest || false;
   }
 
   return false;

--- a/src/functions/sendCandidateResults/application/service/is-delegated-test.ts
+++ b/src/functions/sendCandidateResults/application/service/is-delegated-test.ts
@@ -1,0 +1,58 @@
+import { TestResultSchemasUnion } from '@dvsa/mes-test-schema/categories';
+import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE';
+import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
+import { CatC1UniqueTypes } from '@dvsa/mes-test-schema/categories/C1';
+import { CatC1EUniqueTypes } from '@dvsa/mes-test-schema/categories/C1E';
+import { CatCEUniqueTypes } from '@dvsa/mes-test-schema/categories/CE';
+import { TestResultCatCPCSchema } from '@dvsa/mes-test-schema/categories/CPC';
+import { CatDUniqueTypes } from '@dvsa/mes-test-schema/categories/D';
+import { CatD1UniqueTypes } from '@dvsa/mes-test-schema/categories/D1';
+import { CatD1EUniqueTypes } from '@dvsa/mes-test-schema/categories/D1E';
+import { CatDEUniqueTypes } from '@dvsa/mes-test-schema/categories/DE';
+
+function isDelegatedTest(testResult: TestResultSchemasUnion): boolean {
+
+  if (testResult.category === 'B+E') {
+    return (testResult as CatBEUniqueTypes.TestResult).delegatedTest === true;
+  }
+
+  if (testResult.category === 'C') {
+    return (testResult as CatCUniqueTypes.TestResult).delegatedTest === true;
+  }
+
+  if (testResult.category === 'C+E') {
+    return (testResult as CatCEUniqueTypes.TestResult).delegatedTest === true;
+  }
+
+  if (testResult.category === 'C1') {
+    return (testResult as CatC1UniqueTypes.TestResult).delegatedTest === true;
+  }
+
+  if (testResult.category === 'C1+E') {
+    return (testResult as CatC1EUniqueTypes.TestResult).delegatedTest === true;
+  }
+
+  if (testResult.category === 'D') {
+    return (testResult as CatDUniqueTypes.TestResult).delegatedTest === true;
+  }
+
+  if (testResult.category === 'D+E') {
+    return (testResult as CatDEUniqueTypes.TestResult).delegatedTest === true;
+  }
+
+  if (testResult.category === 'D1') {
+    return (testResult as CatD1UniqueTypes.TestResult).delegatedTest === true;
+  }
+
+  if (testResult.category === 'D1+E') {
+    return (testResult as CatD1EUniqueTypes.TestResult).delegatedTest === true;
+  }
+
+  if (testResult.category === 'CCPC') {
+    return (testResult as TestResultCatCPCSchema).delegatedTest === true;
+  }
+
+  return false;
+}
+
+export default isDelegatedTest;

--- a/src/functions/sendCandidateResults/application/service/is-delegated-test.ts
+++ b/src/functions/sendCandidateResults/application/service/is-delegated-test.ts
@@ -1,54 +1,23 @@
 import { TestResultSchemasUnion } from '@dvsa/mes-test-schema/categories';
-import { CatBEUniqueTypes } from '@dvsa/mes-test-schema/categories/BE';
-import { CatCUniqueTypes } from '@dvsa/mes-test-schema/categories/C';
-import { CatC1UniqueTypes } from '@dvsa/mes-test-schema/categories/C1';
-import { CatC1EUniqueTypes } from '@dvsa/mes-test-schema/categories/C1E';
-import { CatCEUniqueTypes } from '@dvsa/mes-test-schema/categories/CE';
+import { TestResultCommonSchema } from '@dvsa/mes-test-schema/categories/common';
 import { TestResultCatCPCSchema } from '@dvsa/mes-test-schema/categories/CPC';
-import { CatDUniqueTypes } from '@dvsa/mes-test-schema/categories/D';
-import { CatD1UniqueTypes } from '@dvsa/mes-test-schema/categories/D1';
-import { CatD1EUniqueTypes } from '@dvsa/mes-test-schema/categories/D1E';
-import { CatDEUniqueTypes } from '@dvsa/mes-test-schema/categories/DE';
 
 function isDelegatedTest(testResult: TestResultSchemasUnion): boolean {
 
-  if (testResult.category === 'B+E') {
-    return (testResult as CatBEUniqueTypes.TestResult).delegatedTest === true;
+  if (testResult.category === 'B+E'
+    || testResult.category === 'C'
+    || testResult.category === 'C+E'
+    || testResult.category === 'C1'
+    || testResult.category === 'C1+E'
+    || testResult.category === 'D'
+    || testResult.category === 'D+E'
+    || testResult.category === 'D1'
+    || testResult.category === 'D1+E') {
+    return (testResult as TestResultCommonSchema).delegatedTest === true;
   }
 
-  if (testResult.category === 'C') {
-    return (testResult as CatCUniqueTypes.TestResult).delegatedTest === true;
-  }
-
-  if (testResult.category === 'C+E') {
-    return (testResult as CatCEUniqueTypes.TestResult).delegatedTest === true;
-  }
-
-  if (testResult.category === 'C1') {
-    return (testResult as CatC1UniqueTypes.TestResult).delegatedTest === true;
-  }
-
-  if (testResult.category === 'C1+E') {
-    return (testResult as CatC1EUniqueTypes.TestResult).delegatedTest === true;
-  }
-
-  if (testResult.category === 'D') {
-    return (testResult as CatDUniqueTypes.TestResult).delegatedTest === true;
-  }
-
-  if (testResult.category === 'D+E') {
-    return (testResult as CatDEUniqueTypes.TestResult).delegatedTest === true;
-  }
-
-  if (testResult.category === 'D1') {
-    return (testResult as CatD1UniqueTypes.TestResult).delegatedTest === true;
-  }
-
-  if (testResult.category === 'D1+E') {
-    return (testResult as CatD1EUniqueTypes.TestResult).delegatedTest === true;
-  }
-
-  if (testResult.category === 'CCPC') {
+  if (testResult.category === 'CCPC'
+    || testResult.category === 'DCPC') {
     return (testResult as TestResultCatCPCSchema).delegatedTest === true;
   }
 

--- a/src/functions/sendCandidateResults/framework/request-scheduler.ts
+++ b/src/functions/sendCandidateResults/framework/request-scheduler.ts
@@ -126,13 +126,6 @@ export class RequestScheduler implements IRequestScheduler {
       return Promise.resolve();
     }
 
-    // Not all categories seem to have delegated tests
-    // the following categories have: BE, all C, all D, CPC
-
-    // Build a function that selects the test results for only the above mentioned categories
-    // And checks if the delegatedTest is true
-    // Resolve the Promise if it is true
-
     if (isDelegatedTest(testResult)) {
       return Promise.resolve();
     }

--- a/src/functions/sendCandidateResults/framework/request-scheduler.ts
+++ b/src/functions/sendCandidateResults/framework/request-scheduler.ts
@@ -13,6 +13,7 @@ import { ProcessingStatus } from '../domain/submission-outcome.model';
 import { NOTIFY_INTERFACE } from '../domain/interface.constants';
 import { formatApplicationReference } from '@dvsa/mes-microservice-common/domain/tars';
 import { TestResultSchemasUnion } from '@dvsa/mes-test-schema/categories';
+import isDelegatedTest from '../application/service/is-delegated-test';
 
 export interface IRequestScheduler {
   scheduleRequests(testResults: TestResultSchemasUnion[]): Promise<void>[];
@@ -122,6 +123,17 @@ export class RequestScheduler implements IRequestScheduler {
     }
 
     if (!isFail(testResult.activityCode) && !isPass(testResult.activityCode)) {
+      return Promise.resolve();
+    }
+
+    // Not all categories seem to have delegated tests
+    // the following categories have: BE, all C, all D, CPC
+
+    // Build a function that selects the test results for only the above mentioned categories
+    // And checks if the delegatedTest is true
+    // Resolve the Promise if it is true
+
+    if (isDelegatedTest(testResult)) {
       return Promise.resolve();
     }
 


### PR DESCRIPTION
- Disabling Notify for Delegated tests
- Making sure that only those test results are checked which can be delegated tests
- Writing unit tests