### PR TITLE
Revert "MES-6084: Upgrading mes-test-schema version and removing safety questions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -121,9 +121,9 @@
       }
     },
     "@dvsa/mes-test-schema": {
-      "version": "3.31.0",
-      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.31.0.tgz",
-      "integrity": "sha512-da8ggSPk2rlF0hmmM3TJr4udR+S317XjDU7R2dUi7sYGgv/Si/xk0vJAyEYhkejVqh6xxmJmHng7VnZyIIfXDA==",
+      "version": "3.28.0",
+      "resolved": "https://registry.npmjs.org/@dvsa/mes-test-schema/-/mes-test-schema-3.28.0.tgz",
+      "integrity": "sha512-BSuhxpj/LwwVdVtsDxEk5qrjReDfZYa5wpsGqu1wTiA5xOW8LjViHKXPJNzHptG3HqPFl+l1itcypLBzze+CWQ==",
       "dev": true
     },
     "@fimbul/bifrost": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "notifications-node-client": "^4.6.0"
   },
   "devDependencies": {
-    "@dvsa/mes-test-schema": "3.31.0",
+    "@dvsa/mes-test-schema": "3.28.0",
     "@types/aws-lambda": "^8.10.18",
     "@types/aws-sdk": "^2.7.0",
     "@types/axios": "^0.14.0",

--- a/src/functions/sendCandidateResults/application/service/categories/D/__tests__/fault-provider-cat-d.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/D/__tests__/fault-provider-cat-d.spec.ts
@@ -223,13 +223,22 @@ describe('fault-provider-cat-d', () => {
         pcvDoorExercise: {
           drivingFault: true,
         },
+        safetyQuestions: {
+          questions: [
+            {
+              description: 'Safety Question1',
+              outcome: 'DF',
+            },
+          ],
+        },
       };
       const result: Fault [] = getDrivingFaultsCatD(data);
 
-      expect(result.length).toBe(3);
+      expect(result.length).toBe(4);
       expect(result).toEqual([
         { name: Competencies.ancillaryControls, count: 1 },
         { name: Competencies.reverseLeftControl, count: 1 },
+        { name: Competencies.safetyQuestions, count: 1 },
         { name: Competencies.pcvDoorExercise, count: 1 },
       ]);
     });
@@ -240,6 +249,7 @@ describe('fault-provider-cat-d', () => {
       const data: CatDUniqueTypes.TestData = {
         vehicleChecks: {},
         manoeuvres: {},
+        safetyQuestions: {},
         pcvDoorExercise: {},
       };
       const result: Fault[] = getNonStandardFaultsCatD(data, CompetencyOutcome.DF);

--- a/src/functions/sendCandidateResults/application/service/categories/D/fault-provider-cat-d.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/D/fault-provider-cat-d.ts
@@ -9,7 +9,7 @@ import {
 } from '../../fault-provider';
 import { Competencies } from '../../../../domain/competencies';
 import { QuestionOutcome } from '@dvsa/mes-test-schema/categories/common';
-import { PcvDoorExercise } from '@dvsa/mes-test-schema/categories/D/partial';
+import { SafetyQuestionResult, PcvDoorExercise } from '@dvsa/mes-test-schema/categories/D/partial';
 
 export const getDrivingFaultsCatD = (testData: CatDUniqueTypes.TestData | undefined): Fault [] => {
   const drivingFaults: Fault[] = [];
@@ -88,7 +88,14 @@ export const getNonStandardFaultsCatD = (
       .forEach(fault => faults.push(fault));
   }
 
-  // Pcv Door Exercise
+  // Safety Questions
+  if (testData.safetyQuestions &&
+    testData.safetyQuestions.questions) {
+    getSafetyQuestionsFaultCatD(testData.safetyQuestions.questions, faultType)
+    .forEach(fault => faults.push(fault));
+  }
+
+// Pcv Door Exercise
   if (testData.pcvDoorExercise) {
     getPcvDoorExerciseFaultCatD(testData.pcvDoorExercise, faultType)
     .forEach(fault => faults.push(fault));
@@ -107,6 +114,33 @@ export const getVehicleChecksFaultCatD = (
     faultArray.push(
       { name: Competencies.vehicleChecks, count: faultCount === FaultLimit.NON_TRAILER ? 4 : faultCount },
     );
+  }
+  return faultArray;
+};
+
+export const getSafetyQuestionsFaultCatD = (
+  safetyQuestions: SafetyQuestionResult[],
+  faultType: QuestionOutcome): Fault[] => {
+  const faultArray: Fault[] = [];
+
+  if (!safetyQuestions || safetyQuestions.length === 0) {
+    return faultArray;
+  }
+
+  if (faultType !== CompetencyOutcome.DF) {
+    return faultArray;
+  }
+  let gotFault: boolean = false;
+
+  safetyQuestions.forEach((question) => {
+    if (question.outcome === CompetencyOutcome.DF) {
+      gotFault = true;
+    }
+  });
+  if (gotFault) {
+    faultArray.push(
+       { name: Competencies.safetyQuestions, count: 1 },
+     );
   }
   return faultArray;
 };

--- a/src/functions/sendCandidateResults/application/service/categories/D1/__tests__/fault-provider-cat-d1.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/D1/__tests__/fault-provider-cat-d1.spec.ts
@@ -223,13 +223,22 @@ describe('fault-provider-cat-d1', () => {
         pcvDoorExercise: {
           drivingFault: true,
         },
+        safetyQuestions: {
+          questions: [
+            {
+              description: 'Safety Question1',
+              outcome: 'DF',
+            },
+          ],
+        },
       };
       const result: Fault [] = getDrivingFaultsCatD1(data);
 
-      expect(result.length).toBe(3);
+      expect(result.length).toBe(4);
       expect(result).toEqual([
                                { name: Competencies.ancillaryControls, count: 1 },
                                { name: Competencies.reverseLeftControl, count: 1 },
+                               { name: Competencies.safetyQuestions, count: 1 },
                                { name: Competencies.pcvDoorExercise, count: 1 },
       ]);
     });
@@ -241,6 +250,7 @@ describe('fault-provider-cat-d1', () => {
         vehicleChecks: {},
         manoeuvres: {},
         pcvDoorExercise: {},
+        safetyQuestions: {},
       };
       const result: Fault[] = getNonStandardFaultsCatD1(data, CompetencyOutcome.DF);
       expect(result).toEqual([]);

--- a/src/functions/sendCandidateResults/application/service/categories/D1E/__tests__/fault-provider-cat-d1e.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/D1E/__tests__/fault-provider-cat-d1e.spec.ts
@@ -208,13 +208,22 @@ describe('fault-provider-cat-d1e', () => {
         pcvDoorExercise: {
           drivingFault: true,
         },
+        safetyQuestions: {
+          questions: [
+            {
+              description: 'Safety Question1',
+              outcome: 'DF',
+            },
+          ],
+        },
       };
       const result: Fault [] = getDrivingFaultsCatD1E(data);
 
-      expect(result.length).toBe(3);
+      expect(result.length).toBe(4);
       expect(result).toEqual([
                                { name: Competencies.ancillaryControls, count: 1 },
                                { name: Competencies.reverseLeftControl, count: 1 },
+                               { name: Competencies.safetyQuestions, count: 1 },
                                { name: Competencies.pcvDoorExercise, count: 1 },
       ]);
     });
@@ -231,6 +240,7 @@ describe('fault-provider-cat-d1e', () => {
         vehicleChecks: {},
         manoeuvres: {},
         pcvDoorExercise: {},
+        safetyQuestions: {},
       };
       const result: Fault[] = getNonStandardFaultsCatD1E(data, CompetencyOutcome.DF);
       expect(result).toContain({ name: Competencies.uncoupleRecouple, count: 1 });
@@ -244,6 +254,7 @@ describe('fault-provider-cat-d1e', () => {
           selected: false,
         },
         pcvDoorExercise: {},
+        safetyQuestions: {},
       };
       const result: Fault[] = getNonStandardFaultsCatD1E(data, CompetencyOutcome.DF);
       expect(result).toEqual([]);

--- a/src/functions/sendCandidateResults/application/service/categories/D1E/fault-provider-cat-d1e.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/D1E/fault-provider-cat-d1e.ts
@@ -9,7 +9,7 @@ import {
   getVehicleCheckFaultCount,
 } from '../../fault-provider';
 import { Competencies } from '../../../../domain/competencies';
-import { PcvDoorExercise } from '@dvsa/mes-test-schema/categories/D1E/partial';
+import { PcvDoorExercise, SafetyQuestionResult } from '@dvsa/mes-test-schema/categories/D1E/partial';
 
 export const getDrivingFaultsCatD1E = (testData: CatD1EUniqueTypes.TestData | undefined): Fault [] => {
   const drivingFaults: Fault[] = [];
@@ -96,6 +96,13 @@ export const getNonStandardFaultsCatD1E = (
       .forEach(fault => faults.push(fault));
   }
 
+  // Safety Questions
+  if (testData.safetyQuestions &&
+    testData.safetyQuestions.questions) {
+    getSafetyQuestionsFaultCatD1E(testData.safetyQuestions.questions, faultType)
+    .forEach(fault => faults.push(fault));
+  }
+
 // Pcv Door Exercise
   if (testData.pcvDoorExercise) {
     getPcvDoorExerciseFaultCatD1E(testData.pcvDoorExercise, faultType)
@@ -114,6 +121,33 @@ export const getVehicleChecksFaultCatD1E = (
     faultArray.push(
       { name: Competencies.vehicleChecks, count: faultCount === FaultLimit.TRAILER ? 1 : faultCount },
     );
+  }
+  return faultArray;
+};
+
+export const getSafetyQuestionsFaultCatD1E = (
+  safetyQuestions: SafetyQuestionResult[],
+  faultType: QuestionOutcome): Fault[] => {
+  const faultArray: Fault[] = [];
+
+  if (!safetyQuestions || safetyQuestions.length === 0) {
+    return faultArray;
+  }
+
+  if (faultType !== CompetencyOutcome.DF) {
+    return faultArray;
+  }
+  let gotFault: boolean = false;
+
+  safetyQuestions.forEach((question) => {
+    if (question.outcome === CompetencyOutcome.DF) {
+      gotFault = true;
+    }
+  });
+  if (gotFault) {
+    faultArray.push(
+       { name: Competencies.safetyQuestions, count: 1 },
+     );
   }
   return faultArray;
 };

--- a/src/functions/sendCandidateResults/application/service/categories/DE/__tests__/fault-provider-cat-de.spec.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/DE/__tests__/fault-provider-cat-de.spec.ts
@@ -208,13 +208,22 @@ describe('fault-provider-cat-de', () => {
         pcvDoorExercise: {
           drivingFault: true,
         },
+        safetyQuestions: {
+          questions: [
+            {
+              description: 'Safety Question1',
+              outcome: 'DF',
+            },
+          ],
+        },
       };
       const result: Fault [] = getDrivingFaultsCatDE(data);
 
-      expect(result.length).toBe(3);
+      expect(result.length).toBe(4);
       expect(result).toEqual([
         { name: Competencies.ancillaryControls, count: 1 },
         { name: Competencies.reverseLeftControl, count: 1 },
+        { name: Competencies.safetyQuestions, count: 1 },
         { name: Competencies.pcvDoorExercise, count: 1 },
       ]);
     });
@@ -231,6 +240,7 @@ describe('fault-provider-cat-de', () => {
         vehicleChecks: {},
         manoeuvres: {},
         pcvDoorExercise: {},
+        safetyQuestions: {},
       };
       const result: Fault[] = getNonStandardFaultsCatDE(data, CompetencyOutcome.DF);
       expect(result).toContain({ name: Competencies.uncoupleRecouple, count: 1 });
@@ -244,6 +254,7 @@ describe('fault-provider-cat-de', () => {
           selected: false,
         },
         pcvDoorExercise: {},
+        safetyQuestions: {},
       };
       const result: Fault[] = getNonStandardFaultsCatDE(data, CompetencyOutcome.DF);
       expect(result).toEqual([]);

--- a/src/functions/sendCandidateResults/application/service/categories/DE/fault-provider-cat-de.ts
+++ b/src/functions/sendCandidateResults/application/service/categories/DE/fault-provider-cat-de.ts
@@ -9,7 +9,7 @@ import {
   getVehicleCheckFaultCount,
 } from '../../fault-provider';
 import { Competencies } from '../../../../domain/competencies';
-import { PcvDoorExercise } from '@dvsa/mes-test-schema/categories/DE/partial';
+import { SafetyQuestionResult, PcvDoorExercise } from '@dvsa/mes-test-schema/categories/DE/partial';
 
 export const getDrivingFaultsCatDE = (testData: CatDEUniqueTypes.TestData | undefined): Fault [] => {
   const drivingFaults: Fault[] = [];
@@ -95,6 +95,12 @@ export const getNonStandardFaultsCatDE = (
     getVehicleChecksFaultCatDE(testData.vehicleChecks, faultType)
       .forEach(fault => faults.push(fault));
   }
+  // Safety Questions
+  if (testData.safetyQuestions &&
+    testData.safetyQuestions.questions) {
+    getSafetyQuestionsFaultCatDE(testData.safetyQuestions.questions, faultType)
+    .forEach(fault => faults.push(fault));
+  }
 
 // Pcv Door Exercise
   if (testData.pcvDoorExercise) {
@@ -114,6 +120,32 @@ export const getVehicleChecksFaultCatDE = (
     faultArray.push(
       { name: Competencies.vehicleChecks, count: faultCount === FaultLimit.TRAILER ? 1 : faultCount },
     );
+  }
+  return faultArray;
+};
+export const getSafetyQuestionsFaultCatDE = (
+  safetyQuestions: SafetyQuestionResult[],
+  faultType: QuestionOutcome): Fault[] => {
+  const faultArray: Fault[] = [];
+
+  if (!safetyQuestions || safetyQuestions.length === 0) {
+    return faultArray;
+  }
+
+  if (faultType !== CompetencyOutcome.DF) {
+    return faultArray;
+  }
+  let gotFault: boolean = false;
+
+  safetyQuestions.forEach((question) => {
+    if (question.outcome === CompetencyOutcome.DF) {
+      gotFault = true;
+    }
+  });
+  if (gotFault) {
+    faultArray.push(
+       { name: Competencies.safetyQuestions, count: 1 },
+     );
   }
   return faultArray;
 };


### PR DESCRIPTION
Reverting commits for the vehicle checks change

Commits:
- [Mes 6084: Upgrading mes-test-schema version and removing safety questions from cat-Ds (#154)](https://github.com/dvsa/mes-documents-service/commit/500c734a305aa9f79586f4a5ef48a0c3d1a0e7ec )
