### PR TITLE
add workflow to create release manifest for service when tag is cut

### DIFF
--- a/.github/workflows/release-manifest.yaml
+++ b/.github/workflows/release-manifest.yaml
@@ -1,0 +1,16 @@
+name: Create Release Manifest
+on:
+  push:
+    tags:
+      - release-*
+
+permissions:
+  id-token: write
+  contents: write
+
+jobs:
+  release-manifest:
+    uses: dvsa/des-workflow-actions/.github/workflows/release-manifest.yaml@main
+    with:
+      component: 'api'
+    secrets: inherit


### PR DESCRIPTION
## Description

add workflow to create release manifest for service when tag is cut

Related issue: [MES-9153](https://dvsa.atlassian.net/browse/MES-9153)

## Before submitting (or marking as "ready for review")

- [ ] Does the pull request title follow the [conventional commit](https://www.conventionalcommits.org/en/v1.0.0/) specification?
- [x] Have you performed a self-review of the code
- [ ] Have you have added tests that prove the fix or feature is effective and working
- [ ] Did you make sure to update any documentation relating to this change?
